### PR TITLE
Fix integration tests

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,3 +3,6 @@ ipdb
 pytest
 flake8
 requests
+httpx==0.19.0
+pytest-asyncio==0.15.1
+requests-toolbelt==0.9.1


### PR DESCRIPTION
This PR fixes the integration tests, locally. As the POST calls are async they need to use an async client. In addition I have added `requests-toolbelt` which wraps the multipart stuff more neatly.

The tests could either be expanded here to cover all endpoints or in later work?

