### PR TITLE
Handle text responses

### DIFF
--- a/app/ags.py
+++ b/app/ags.py
@@ -5,51 +5,14 @@ import logging
 from pathlib import Path
 import re
 import subprocess
-from textwrap import dedent
 from typing import Tuple, Optional
 
-from jinja2 import Template
 import python_ags4
 from python_ags4 import AGS4
 
+from app.response_templates import PLAIN_TEXT_TEMPLATE, RESPONSE_TEMPLATE
+
 logger = logging.getLogger(__name__)
-
-RESPONSE_TEMPLATE = dedent("""
-    File Name: \t {filename}
-    File Size: \t {filesize:0.0f} kB
-    Time (UTC): \t {time_utc}
-
-    {message}
-    """).strip()
-
-PLAIN_TEXT_TEMPLATE = Template("""
-{{ filename }}: {{ message }}
-
-# Metadata
-
-File size: {{ filesize }} bytes
-Checker: {{ checker }}
-{%- if dictionary != '' %}
-Dictionary: {{ dictionary }}
-{%- endif %}
-Time: {{ time }}
-
-{% if not valid -%}
-# Errors
-
-{% for key in errors -%}
-## {{ key }}
-
-{% for item in errors[key] -%}
-{%- if item.line == '-' -%}
-Group: {{ item.group }} - {{ item.desc }}
-{% else -%}
-Line: {{ item.line }} - {{ item.desc }}
-{% endif %}
-{%- endfor %}
-{% endfor %}
-{%- endif -%}
-""".strip())
 
 
 def validate(filename: Path) -> dict:

--- a/app/response_templates.py
+++ b/app/response_templates.py
@@ -1,0 +1,41 @@
+# Text templates used to build responses.
+from textwrap import dedent
+
+from jinja2 import Template
+
+RESPONSE_TEMPLATE = dedent("""
+    File Name: \t {filename}
+    File Size: \t {filesize:0.0f} kB
+    Time (UTC): \t {time_utc}
+
+    {message}
+    """).strip()
+
+PLAIN_TEXT_TEMPLATE = Template("""
+{{ filename }}: {{ message }}
+
+# Metadata
+
+File size: {{ filesize }} bytes
+Checker: {{ checker }}
+{%- if dictionary != '' %}
+Dictionary: {{ dictionary }}
+{%- endif %}
+Time: {{ time }}
+
+{% if not valid -%}
+# Errors
+
+{% for key in errors -%}
+## {{ key }}
+
+{% for item in errors[key] -%}
+{%- if item.line == '-' -%}
+Group: {{ item.group }} - {{ item.desc }}
+{% else -%}
+Line: {{ item.line }} - {{ item.desc }}
+{% endif %}
+{%- endfor %}
+{% endfor %}
+{%- endif -%}
+""".strip())

--- a/app/routes.py
+++ b/app/routes.py
@@ -71,13 +71,14 @@ async def validate(background_tasks: BackgroundTasks,
     contents = await file.read()
     local_ags_file = tmp_dir / file.filename
     local_ags_file.write_bytes(contents)
-    log = ags.validate(local_ags_file)
+    result = ags.validate(local_ags_file)
     if fmt == Format.TEXT:
+        log = ags.to_plain_text(result)
         logfile = tmp_dir / 'results.log'
         logfile.write_text(log)
         response = FileResponse(logfile, media_type="text/plain")
     else:
-        data = [log]
+        data = [result]
         response = prepare_validation_response(request, data)
     return response
 
@@ -100,7 +101,7 @@ async def validate_many(background_tasks: BackgroundTasks,
                 contents = await file.read()
                 local_ags_file = tmp_dir / file.filename
                 local_ags_file.write_bytes(contents)
-                log = ags.validate(local_ags_file)
+                log = ags.to_plain_text(ags.validate(local_ags_file))
                 f.write(log)
                 f.write('=' * 80 + '\n')
         response = FileResponse(full_logfile, media_type="text/plain")

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -1,5 +1,7 @@
 """Shared pytest data."""
 
+FROZEN_TIME = "2021-08-23 14:25:43"
+
 ISVALID_RSP_DATA = [
     ('example1.ags', True),
     ('nonsense.ags', False),
@@ -9,17 +11,6 @@ ISVALID_RSP_DATA = [
     ('random_binary.ags', False),
     ('real/CG014058_F.ags', False),
     ('real/Blackburn Southern Bypass.ags', False),  # this file contains BOM character
-]
-
-VALIDATION_TEXT_RSP_DATA = [
-    ('example1.ags', ('All checks passed!', 3)),
-    ('nonsense.ags', (r'7 error\(s\) found in file!', 0)),
-    ('empty.ags', (r'4 error\(s\) found in file!', 0)),
-    ('real/A3040_03.ags', (r'5733 error\(s\) found in file!', 258)),
-    ('example1.xlsx', ('ERROR: Only .ags files are accepted as input.', 11)),
-    ('random_binary.ags', ('ERROR: Unreadable character "á" at position 1 on line: 1\nStarting:', 1)),
-    ('real/CG014058_F.ags', (r'ERROR: Unreadable character "æ" at position 80 on line: 263\nStarting: "WS2"', 49)),
-    ('real/Blackburn Southern Bypass.ags', (r'93 error\(s\) found in file!', 6)),  # this file contains BOM character
 ]
 
 GOOD_FILE_DATA = [

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -21,3 +21,16 @@ VALIDATION_TEXT_RSP_DATA = [
     ('real/CG014058_F.ags', (r'ERROR: Unreadable character "æ" at position 80 on line: 263\nStarting: "WS2"', 49)),
     ('real/Blackburn Southern Bypass.ags', (r'93 error\(s\) found in file!', 6)),  # this file contains BOM character
 ]
+
+GOOD_FILE_DATA = [
+    ('example1.ags', 'SUCCESS: example1.ags converted to example1.xlsx'),
+    ('example1.xlsx', 'SUCCESS: example1.xlsx converted to example1.ags'),
+]
+
+BAD_FILE_DATA = [
+    ('nonsense.ags', ('IndexError: At least one sheet must be visible', 0)),
+    ('empty.ags', ('IndexError: At least one sheet must be visible', 0)),
+    ('dummy.xlsx', ("AttributeError: 'DataFrame' object has no attribute 'HEADING'", 5)),
+    ('random_binary.ags', ('IndexError: At least one sheet must be visible', 1)),
+    ('real/A3040_03.ags', ("UnboundLocalError: local variable 'group' referenced before assignment", 258)),
+]

--- a/test/fixtures_plain_text.py
+++ b/test/fixtures_plain_text.py
@@ -1,0 +1,183 @@
+PLAIN_TEXT_RESPONSES = {
+    'example1.ags': """
+example1.ags: All checks passed!
+
+# Metadata
+
+File size: 4039 bytes
+Checker: python_ags4 v0.3.6
+Dictionary: Standard_dictionary_v4_1.ags
+Time: 2021-08-23 14:25:43+00:00
+""",
+    'nonsense.ags': """
+nonsense.ags: 7 error(s) found in file!
+
+# Metadata
+
+File size: 9 bytes
+Checker: python_ags4 v0.3.6
+Dictionary: Standard_dictionary_v4_1.ags
+Time: 2021-08-23 14:25:43+00:00
+
+# Errors
+
+## Rule 2a
+
+Line: 1 - Is not terminated by <CR> and <LF> characters.
+
+## Rule 3
+
+Line: 1 - Does not start with a valid data descriptor.
+
+## Rule 5
+
+Line: 1 - Contains fields that are not enclosed in double quotes.
+
+## Rule 13
+
+Group: PROJ - PROJ table not found.
+
+## Rule 14
+
+Group: TRAN - TRAN table not found.
+
+## Rule 15
+
+Group: UNIT - UNIT table not found.
+
+## Rule 17
+
+Group: TYPE - TYPE table not found.
+""",
+    'random_binary.ags': """
+random_binary.ags: Unable to open file.
+
+# Metadata
+
+File size: 1024 bytes
+Checker: python_ags4 v0.3.6
+Time: 2021-08-23 14:25:43+00:00
+
+# Errors
+
+## UnicodeDecodeError
+
+Line: 1 - invalid continuation byte
+""",
+    'real/Blackburn Southern Bypass.ags': """
+Blackburn Southern Bypass.ags: 93 error(s) found in file!
+
+# Metadata
+
+File size: 6566 bytes
+Checker: python_ags4 v0.3.6
+Time: 2021-08-23 14:25:43+00:00
+
+# Errors
+
+## Rule 1
+
+Line: 1 - Has Non-ASCII character(s).
+
+## Rule 2a
+
+Line: 1 - Is not terminated by <CR> and <LF> characters.
+Line: 2 - Is not terminated by <CR> and <LF> characters.
+Line: 3 - Is not terminated by <CR> and <LF> characters.
+Line: 4 - Is not terminated by <CR> and <LF> characters.
+Line: 5 - Is not terminated by <CR> and <LF> characters.
+Line: 6 - Is not terminated by <CR> and <LF> characters.
+Line: 7 - Is not terminated by <CR> and <LF> characters.
+Line: 8 - Is not terminated by <CR> and <LF> characters.
+Line: 9 - Is not terminated by <CR> and <LF> characters.
+Line: 10 - Is not terminated by <CR> and <LF> characters.
+Line: 11 - Is not terminated by <CR> and <LF> characters.
+Line: 12 - Is not terminated by <CR> and <LF> characters.
+Line: 13 - Is not terminated by <CR> and <LF> characters.
+Line: 14 - Is not terminated by <CR> and <LF> characters.
+Line: 15 - Is not terminated by <CR> and <LF> characters.
+Line: 16 - Is not terminated by <CR> and <LF> characters.
+Line: 17 - Is not terminated by <CR> and <LF> characters.
+Line: 18 - Is not terminated by <CR> and <LF> characters.
+Line: 19 - Is not terminated by <CR> and <LF> characters.
+Line: 20 - Is not terminated by <CR> and <LF> characters.
+Line: 21 - Is not terminated by <CR> and <LF> characters.
+Line: 22 - Is not terminated by <CR> and <LF> characters.
+Line: 23 - Is not terminated by <CR> and <LF> characters.
+Line: 24 - Is not terminated by <CR> and <LF> characters.
+Line: 25 - Is not terminated by <CR> and <LF> characters.
+Line: 26 - Is not terminated by <CR> and <LF> characters.
+Line: 27 - Is not terminated by <CR> and <LF> characters.
+Line: 28 - Is not terminated by <CR> and <LF> characters.
+Line: 29 - Is not terminated by <CR> and <LF> characters.
+Line: 30 - Is not terminated by <CR> and <LF> characters.
+Line: 31 - Is not terminated by <CR> and <LF> characters.
+Line: 32 - Is not terminated by <CR> and <LF> characters.
+Line: 33 - Is not terminated by <CR> and <LF> characters.
+Line: 34 - Is not terminated by <CR> and <LF> characters.
+Line: 35 - Is not terminated by <CR> and <LF> characters.
+Line: 36 - Is not terminated by <CR> and <LF> characters.
+Line: 37 - Is not terminated by <CR> and <LF> characters.
+Line: 38 - Is not terminated by <CR> and <LF> characters.
+Line: 39 - Is not terminated by <CR> and <LF> characters.
+Line: 40 - Is not terminated by <CR> and <LF> characters.
+Line: 41 - Is not terminated by <CR> and <LF> characters.
+Line: 42 - Is not terminated by <CR> and <LF> characters.
+Line: 43 - Is not terminated by <CR> and <LF> characters.
+Line: 44 - Is not terminated by <CR> and <LF> characters.
+Line: 45 - Is not terminated by <CR> and <LF> characters.
+Line: 46 - Is not terminated by <CR> and <LF> characters.
+Line: 47 - Is not terminated by <CR> and <LF> characters.
+Line: 48 - Is not terminated by <CR> and <LF> characters.
+Line: 49 - Is not terminated by <CR> and <LF> characters.
+Line: 50 - Is not terminated by <CR> and <LF> characters.
+Line: 51 - Is not terminated by <CR> and <LF> characters.
+Line: 52 - Is not terminated by <CR> and <LF> characters.
+Line: 53 - Is not terminated by <CR> and <LF> characters.
+Line: 54 - Is not terminated by <CR> and <LF> characters.
+Line: 55 - Is not terminated by <CR> and <LF> characters.
+Line: 56 - Is not terminated by <CR> and <LF> characters.
+Line: 57 - Is not terminated by <CR> and <LF> characters.
+Line: 58 - Is not terminated by <CR> and <LF> characters.
+Line: 59 - Is not terminated by <CR> and <LF> characters.
+Line: 60 - Is not terminated by <CR> and <LF> characters.
+Line: 61 - Is not terminated by <CR> and <LF> characters.
+Line: 62 - Is not terminated by <CR> and <LF> characters.
+Line: 63 - Is not terminated by <CR> and <LF> characters.
+Line: 64 - Is not terminated by <CR> and <LF> characters.
+Line: 65 - Is not terminated by <CR> and <LF> characters.
+Line: 66 - Is not terminated by <CR> and <LF> characters.
+Line: 67 - Is not terminated by <CR> and <LF> characters.
+Line: 68 - Is not terminated by <CR> and <LF> characters.
+Line: 69 - Is not terminated by <CR> and <LF> characters.
+Line: 70 - Is not terminated by <CR> and <LF> characters.
+Line: 71 - Is not terminated by <CR> and <LF> characters.
+Line: 72 - Is not terminated by <CR> and <LF> characters.
+Line: 73 - Is not terminated by <CR> and <LF> characters.
+Line: 74 - Is not terminated by <CR> and <LF> characters.
+Line: 75 - Is not terminated by <CR> and <LF> characters.
+Line: 76 - Is not terminated by <CR> and <LF> characters.
+Line: 77 - Is not terminated by <CR> and <LF> characters.
+Line: 78 - Is not terminated by <CR> and <LF> characters.
+Line: 79 - Is not terminated by <CR> and <LF> characters.
+Line: 80 - Is not terminated by <CR> and <LF> characters.
+Line: 81 - Is not terminated by <CR> and <LF> characters.
+Line: 82 - Is not terminated by <CR> and <LF> characters.
+Line: 83 - Is not terminated by <CR> and <LF> characters.
+Line: 84 - Is not terminated by <CR> and <LF> characters.
+Line: 85 - Is not terminated by <CR> and <LF> characters.
+Line: 86 - Is not terminated by <CR> and <LF> characters.
+Line: 87 - Is not terminated by <CR> and <LF> characters.
+Line: 88 - Is not terminated by <CR> and <LF> characters.
+Line: 89 - Is not terminated by <CR> and <LF> characters.
+Line: 90 - Is not terminated by <CR> and <LF> characters.
+
+## Rule 3
+
+Line: 1 - Does not start with a valid data descriptor.
+
+## Rule 5
+
+Line: 1 - Contains fields that are not enclosed in double quotes.
+"""
+}

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -48,10 +48,11 @@ async def test_isvalid(async_client, filename, expected):
     assert body['data'][0] == expected
 
 
+@pytest.mark.parametrize('fmt,', ['', '?fmt=json'])
 @pytest.mark.parametrize('filename, expected',
                          [item for item in JSON_RESPONSES.items()])
 @pytest.mark.asyncio
-async def test_validate_json(async_client, filename, expected):
+async def test_validate_json(async_client, filename, expected, fmt):
     # Arrange
     filename = TEST_FILE_DIR / filename
     mp_encoder = MultipartEncoder(
@@ -60,7 +61,7 @@ async def test_validate_json(async_client, filename, expected):
     # Act
     async with async_client as ac:
         response = await ac.post(
-            '/validate/',
+            '/validate/' + fmt,
             headers={'Content-Type': mp_encoder.content_type},
             data=mp_encoder.to_string())
 
@@ -76,8 +77,9 @@ async def test_validate_json(async_client, filename, expected):
     assert body['data'][0]['filename'] == expected['filename']
 
 
+@pytest.mark.parametrize('fmt,', ['', '?fmt=json'])
 @pytest.mark.asyncio
-async def test_validatemany_json(async_client):
+async def test_validatemany_json(async_client, fmt):
     # Arrange
     files = []
     for name in JSON_RESPONSES.keys():
@@ -89,7 +91,7 @@ async def test_validatemany_json(async_client):
     # Act
     async with async_client as ac:
         response = await ac.post(
-            '/validatemany/',
+            '/validatemany/' + fmt,
             headers={'Content-Type': mp_encoder.content_type},
             data=mp_encoder.to_string())
 

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -125,6 +125,30 @@ async def test_validate_text(async_client, filename, expected):
     assert response.text.strip() == expected.strip()
 
 
+@freeze_time(FROZEN_TIME)
+@pytest.mark.asyncio
+async def test_validatemany_text(async_client):
+    # Arrange
+    files = []
+    for name in PLAIN_TEXT_RESPONSES.keys():
+        filename = TEST_FILE_DIR / name
+        file = ('files', (filename.name, open(filename, 'rb'), 'text/plain'))
+        files.append(file)
+    mp_encoder = MultipartEncoder(fields=files)
+
+    # Act
+    async with async_client as ac:
+        response = await ac.post(
+            '/validatemany/?fmt=text',
+            headers={'Content-Type': mp_encoder.content_type},
+            data=mp_encoder.to_string())
+
+    # Assert
+    assert response.status_code == 200
+    for log in PLAIN_TEXT_RESPONSES.values():
+        assert log.strip() in response.text
+
+
 @pytest.fixture(scope="function")
 def client():
     return TestClient(app)

--- a/test/unit/test_ags.py
+++ b/test/unit/test_ags.py
@@ -6,8 +6,8 @@ from freezegun import freeze_time
 import pytest
 
 from app import ags
+from test.fixtures import BAD_FILE_DATA, GOOD_FILE_DATA, ISVALID_RSP_DATA
 from test.fixtures_json import JSON_RESPONSES
-from test.fixtures import ISVALID_RSP_DATA
 from test.fixtures_plain_text import PLAIN_TEXT_RESPONSES
 
 TEST_FILE_DIR = Path(__file__).parent.parent / 'files'
@@ -31,10 +31,7 @@ def test_validate(filename, expected):
         assert response[key] == expected[key]
 
 
-@pytest.mark.parametrize('filename, expected', [
-    ('example1.ags', 'SUCCESS: example1.ags converted to example1.xlsx'),
-    ('example1.xlsx', 'SUCCESS: example1.xlsx converted to example1.ags'),
-])
+@pytest.mark.parametrize('filename, expected', GOOD_FILE_DATA)
 def test_convert(tmp_path, filename, expected):
     # Arrange
     filename = TEST_FILE_DIR / filename
@@ -50,13 +47,7 @@ def test_convert(tmp_path, filename, expected):
     assert re.search(expected, log)
 
 
-@pytest.mark.parametrize('filename, expected', [
-    ('nonsense.ags', ('IndexError: At least one sheet must be visible', 0)),
-    ('empty.ags', ('IndexError: At least one sheet must be visible', 0)),
-    ('dummy.xlsx', ("AttributeError: 'DataFrame' object has no attribute 'HEADING'", 5)),
-    ('random_binary.ags', ('IndexError: At least one sheet must be visible', 1)),
-    ('real/A3040_03.ags', ("UnboundLocalError: local variable 'group' referenced before assignment", 258)),
-])
+@pytest.mark.parametrize('filename, expected', BAD_FILE_DATA)
 def test_convert_bad_files(tmp_path, filename, expected):
     # Arrange
     filename = TEST_FILE_DIR / filename

--- a/test/unit/test_ags.py
+++ b/test/unit/test_ags.py
@@ -27,7 +27,6 @@ def test_validate(filename, expected):
     # Check that metadata fields are correct
     for key in ['filename', 'filesize', 'checker', 'time', 'dictionary',
                 'errors', 'message', 'valid']:
-        print(key)
         assert response[key] == expected[key]
 
 
@@ -88,7 +87,6 @@ def test_is_valid(filename, expected):
 def test_to_plain_text(response, expected):
     # Act
     text = ags.to_plain_text(response)
-    print(text)
 
     # Assert
     assert text.strip() == expected.strip()

--- a/test/unit/test_ags.py
+++ b/test/unit/test_ags.py
@@ -78,13 +78,14 @@ def test_is_valid(filename, expected):
     assert result == expected
 
 
-@pytest.mark.parametrize('response, expected', [
-    (JSON_RESPONSES['example1.ags'], PLAIN_TEXT_RESPONSES['example1.ags']),
-    (JSON_RESPONSES['nonsense.ags'], PLAIN_TEXT_RESPONSES['nonsense.ags']),
-    (JSON_RESPONSES['random_binary.ags'], PLAIN_TEXT_RESPONSES['random_binary.ags']),
-    (JSON_RESPONSES['real/Blackburn Southern Bypass.ags'], PLAIN_TEXT_RESPONSES['real/Blackburn Southern Bypass.ags']),
-])
-def test_to_plain_text(response, expected):
+@pytest.mark.parametrize('filename', [
+    'example1.ags', 'nonsense.ags', 'random_binary.ags',
+    'real/Blackburn Southern Bypass.ags'])
+def test_to_plain_text(filename):
+    # Arrange
+    response = JSON_RESPONSES[filename]
+    expected = PLAIN_TEXT_RESPONSES[filename]
+
     # Act
     text = ags.to_plain_text(response)
 

--- a/test/unit/test_ags.py
+++ b/test/unit/test_ags.py
@@ -8,6 +8,7 @@ import pytest
 from app import ags
 from test.fixtures_json import JSON_RESPONSES
 from test.fixtures import ISVALID_RSP_DATA
+from test.fixtures_plain_text import PLAIN_TEXT_RESPONSES
 
 TEST_FILE_DIR = Path(__file__).parent.parent / 'files'
 
@@ -79,9 +80,25 @@ def test_convert_bad_files(tmp_path, filename, expected):
 def test_is_valid(filename, expected):
     # Arrange
     filename = TEST_FILE_DIR / filename
+    expected = expected.strip()
 
     # Act
     result = ags.is_valid(filename)
 
     # Assert
     assert result == expected
+
+
+@pytest.mark.parametrize('response, expected', [
+    (JSON_RESPONSES['example1.ags'], PLAIN_TEXT_RESPONSES['example1.ags']),
+    (JSON_RESPONSES['nonsense.ags'], PLAIN_TEXT_RESPONSES['nonsense.ags']),
+    (JSON_RESPONSES['random_binary.ags'], PLAIN_TEXT_RESPONSES['random_binary.ags']),
+    (JSON_RESPONSES['real/Blackburn Southern Bypass.ags'], PLAIN_TEXT_RESPONSES['real/Blackburn Southern Bypass.ags']),
+])
+def test_to_plain_text(response, expected):
+    # Act
+    text = ags.to_plain_text(response)
+    print(text)
+
+    # Assert
+    assert text.strip() == expected.strip()

--- a/test/unit/test_ags.py
+++ b/test/unit/test_ags.py
@@ -80,7 +80,6 @@ def test_convert_bad_files(tmp_path, filename, expected):
 def test_is_valid(filename, expected):
     # Arrange
     filename = TEST_FILE_DIR / filename
-    expected = expected.strip()
 
     # Act
     result = ags.is_valid(filename)

--- a/test/unit/test_ags.py
+++ b/test/unit/test_ags.py
@@ -6,14 +6,14 @@ from freezegun import freeze_time
 import pytest
 
 from app import ags
-from test.fixtures import BAD_FILE_DATA, GOOD_FILE_DATA, ISVALID_RSP_DATA
+from test.fixtures import BAD_FILE_DATA, FROZEN_TIME, GOOD_FILE_DATA, ISVALID_RSP_DATA
 from test.fixtures_json import JSON_RESPONSES
 from test.fixtures_plain_text import PLAIN_TEXT_RESPONSES
 
 TEST_FILE_DIR = Path(__file__).parent.parent / 'files'
 
 
-@freeze_time("2021-08-23 14:25:43")
+@freeze_time(FROZEN_TIME)
 @pytest.mark.parametrize('filename, expected',
                          [item for item in JSON_RESPONSES.items()])
 def test_validate(filename, expected):


### PR DESCRIPTION
This PR fully handles text responses.

All tests should pass. Text responses can be checked manually via the `/docs` endpoint.