### PR TITLE
Prepend BGS rules with 'BGS data validation:'

### DIFF
--- a/app/bgs_rules.py
+++ b/app/bgs_rules.py
@@ -368,15 +368,15 @@ def check_sample_referencing(tables: dict) -> List[dict]:
 
 
 BGS_RULES = {
-    'Required Groups': check_required_groups,
-    'Required BGS Groups': check_required_bgs_groups,
-    'Spatial Referencing': check_spatial_referencing_system,
-    'Eastings/Northings Present': check_eastings_northings_present,
-    'Eastings/Northings Range': check_eastings_northings_range,
-    'Drill Depth Present': check_drill_depth_present,
-    'Drill Depth GEOL Record': check_drill_depth_geol_record,
-    'LOCA within Great Britain': check_loca_within_great_britain,
-    'LOCA_LOCX is not duplicate of other column': check_locx_is_not_duplicate_of_other_column,
-    'LOCA_ID references': check_loca_id_references_are_valid,
-    'Sample Referencing': check_sample_referencing,
+    'BGS data validation: Required Groups': check_required_groups,
+    'BGS data validation: Required BGS Groups': check_required_bgs_groups,
+    'BGS data validation: Spatial Referencing': check_spatial_referencing_system,
+    'BGS data validation: Eastings/Northings Present': check_eastings_northings_present,
+    'BGS data validation: Eastings/Northings Range': check_eastings_northings_range,
+    'BGS data validation: Drill Depth Present': check_drill_depth_present,
+    'BGS data validation: Drill Depth GEOL Record': check_drill_depth_geol_record,
+    'BGS data validation: LOCA within Great Britain': check_loca_within_great_britain,
+    'BGS data validation: LOCA_LOCX is not duplicate of other column': check_locx_is_not_duplicate_of_other_column,
+    'BGS data validation: LOCA_ID references': check_loca_id_references_are_valid,
+    'BGS data validation: Sample Referencing': check_sample_referencing,
 }

--- a/app/checkers.py
+++ b/app/checkers.py
@@ -150,7 +150,8 @@ def get_coord_column_type_errors(tables: dict, coord_columns: List[str]) -> dict
 
     if bad_columns:
         error_message = f"Coordinate columns have non-numeric TYPE: {', '.join(bad_columns)}"
-        errors = {"Non-numeric coordinate types": [{'line': '-', 'group': 'LOCA', 'desc': error_message}]}
+        errors = {"BGS data validation: Non-numeric coordinate types":
+                  [{'line': '-', 'group': 'LOCA', 'desc': error_message}]}
     else:
         errors = {}
 

--- a/test/unit/test_bgs_rules.py
+++ b/test/unit/test_bgs_rules.py
@@ -18,7 +18,7 @@ def test_required_groups():
                 'desc': 'Required groups not present: ABBR, TYPE, UNIT, (LOCA or HOLE)'}
     tables, _, _ = load_AGS4_as_numeric(filename)
 
-    errors = BGS_RULES['Required Groups'](tables)
+    errors = BGS_RULES['BGS data validation: Required Groups'](tables)
 
     assert errors == [expected]
 
@@ -31,7 +31,7 @@ def test_required_bgs_groups():
                 'desc': 'Required BGS groups not present: GEOL'}
     tables, _, _ = load_AGS4_as_numeric(filename)
 
-    errors = BGS_RULES['Required BGS Groups'](tables)
+    errors = BGS_RULES['BGS data validation: Required BGS Groups'](tables)
 
     assert errors == [expected]
 
@@ -44,7 +44,7 @@ def test_spatial_referencing():
                 'desc': 'Spatial referencing system not in LOCA_GREF, LOCA_LREF or LOCA_LLZ!'}
     tables, _, _ = load_AGS4_as_numeric(filename)
 
-    errors = BGS_RULES['Spatial Referencing'](tables)
+    errors = BGS_RULES['BGS data validation: Spatial Referencing'](tables)
 
     assert errors == [expected]
 
@@ -62,7 +62,7 @@ def test_eastings_northings_present():
     ]
     tables, _, _ = load_AGS4_as_numeric(filename)
 
-    errors = BGS_RULES['Eastings/Northings Present'](tables)
+    errors = BGS_RULES['BGS data validation: Eastings/Northings Present'](tables)
 
     assert errors == expected
 
@@ -80,7 +80,7 @@ def test_eastings_northings_range():
     ]
     tables, _, _ = load_AGS4_as_numeric(filename)
 
-    errors = BGS_RULES['Eastings/Northings Range'](tables)
+    errors = BGS_RULES['BGS data validation: Eastings/Northings Range'](tables)
 
     assert errors == expected
 
@@ -98,7 +98,7 @@ def test_drill_depth_present():
     ]
     tables, _, _ = load_AGS4_as_numeric(filename)
 
-    errors = BGS_RULES['Drill Depth Present'](tables)
+    errors = BGS_RULES['BGS data validation: Drill Depth Present'](tables)
 
     assert errors == expected
 
@@ -114,7 +114,7 @@ def test_drill_depth_geol_record():
     ]
     tables, _, _ = load_AGS4_as_numeric(filename)
 
-    errors = BGS_RULES['Drill Depth GEOL Record'](tables)
+    errors = BGS_RULES['BGS data validation: Drill Depth GEOL Record'](tables)
 
     assert errors == expected
 
@@ -139,7 +139,7 @@ def test_loca_within_great_britain():
 
     tables, _, _ = load_AGS4_as_numeric(filename)
 
-    errors = BGS_RULES['LOCA within Great Britain'](tables)
+    errors = BGS_RULES['BGS data validation: LOCA within Great Britain'](tables)
 
     assert errors == expected
 
@@ -157,7 +157,7 @@ def test_loca_locx_is_not_duplicate_of_other_column():
     ]
     tables, _, _ = load_AGS4_as_numeric(filename)
 
-    errors = BGS_RULES['LOCA_LOCX is not duplicate of other column'](tables)
+    errors = BGS_RULES['BGS data validation: LOCA_LOCX is not duplicate of other column'](tables)
 
     assert errors == expected
 
@@ -175,7 +175,7 @@ def test_loca_references_are_valid():
     ]
     tables, _, _ = load_AGS4_as_numeric(filename)
 
-    errors = BGS_RULES['LOCA_ID references'](tables)
+    errors = BGS_RULES['BGS data validation: LOCA_ID references'](tables)
 
     assert errors == expected
 
@@ -183,7 +183,7 @@ def test_loca_references_are_valid():
 def test_non_numeric_coord_types():
     # Arrange
     filename = TEST_FILE_DIR / 'bgs_rules' / 'non_numeric_coord_types.ags'
-    expected = {'Non-numeric coordinate types': [
+    expected = {'BGS data validation: Non-numeric coordinate types': [
         {"desc": "Coordinate columns have non-numeric TYPE: LOCA_NATE (X), LOCA_NATN (X)",
          "group": "LOCA",
          "line": "-"}
@@ -204,6 +204,6 @@ def test_sample_referential_integrity(filename, expected):
     filename = TEST_FILE_DIR / 'bgs_rules' / filename
     tables, _, _ = load_AGS4_as_numeric(filename)
 
-    errors = BGS_RULES['Sample Referencing'](tables)
+    errors = BGS_RULES['BGS data validation: Sample Referencing'](tables)
 
     assert errors == expected

--- a/test/unit/test_checkers.py
+++ b/test/unit/test_checkers.py
@@ -45,19 +45,20 @@ def test_check_ags(filename, expected_rules):
 
 @pytest.mark.parametrize('filename, expected_rules, file_read_message', [
     ('example_ags.ags',
-     ['Required BGS Groups', 'Spatial Referencing'], None),
+     ['BGS data validation: Required BGS Groups', 'BGS data validation: Spatial Referencing'], None),
     ('random_binary.ags',
-     ['Required Groups', 'Required BGS Groups'], None),
+     ['BGS data validation: Required Groups', 'BGS data validation: Required BGS Groups'], None),
     ('nonsense.ags',
-     ['Required Groups', 'Required BGS Groups'], None),
+     ['BGS data validation: Required Groups', 'BGS data validation: Required BGS Groups'], None),
     ('empty.ags',
-     ['Required Groups', 'Required BGS Groups'], None),
+     ['BGS data validation: Required Groups', 'BGS data validation: Required BGS Groups'], None),
     ('real/Southwark.ags',
-     ['Sample Referencing'], None),
+     ['BGS data validation: Sample Referencing'], None),
     ('real/Mount Severn- Environment Agency.ags',
-     ['Non-numeric coordinate types', 'Spatial Referencing'], None),
+     ['BGS data validation: Non-numeric coordinate types', 'BGS data validation: Spatial Referencing'], None),
     ('real/A112794-16 Glenally_Road_Factual_FINAL.ags',
-     ['Spatial Referencing', 'LOCA within Great Britain', 'Sample Referencing'], None),
+     ['BGS data validation: Spatial Referencing', 'BGS data validation: LOCA within Great Britain',
+      'BGS data validation: Sample Referencing'], None),
     ('real/A3040_03.ags',
      ['File read error'], 'ERROR: File contains duplicate headers'),
     ('real/43370.ags',  # File has no errors
@@ -65,7 +66,7 @@ def test_check_ags(filename, expected_rules):
     ('real/JohnStPrimarySchool.ags',
      ['File read error'], 'ERROR: UNIT and/or TYPE rows missing OR mismatched column numbers'),
     ('real/19684.ags',
-     ['Required Groups', 'Required BGS Groups'], None),
+     ['BGS data validation: Required Groups', 'BGS data validation: Required BGS Groups'], None),
     # This file crashes because it asks for user input
     # ('real/E52A4379 (2).ags', {}),
 ])


### PR DESCRIPTION
### Description

This merge request prepends "BGS data validation:" to the rule names for the BGS rules.

### To test

Run the API and validate `example_ags.ags` with both AGS and BGS validator.  The output should include BGS data validation in the rule names:

```
================================================================================
example_ags.ags: 2 error(s) found in file!

# Metadata

File size: 4039 bytes
Checkers: ['python_ags4 v0.3.6', 'bgs_rules v2.0.0']
Dictionary: Standard_dictionary_v4_0_4.ags
Time: 2021-10-11 13:58:11.432016+00:00

7 groups identified in file: PROJ ABBR TRAN TYPE UNIT LOCA SAMP
Optional FILE group present: False
Optional DICT group present: False
1 data rows in LOCA group
1 projects found: 121415 (ACME Gas Works Redevelopment)

# Errors

## BGS data validation: Required BGS Groups

Group:  - Required BGS groups not present: GEOL

## BGS data validation: Spatial Referencing

Group: LOCA - Spatial referencing system not in LOCA_GREF, LOCA_LREF or LOCA_LLZ!

================================================================================
```