### PR TITLE
Added lint & test jobs to workflow

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -1,0 +1,64 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Lint & Test Python package
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  release:
+    types:
+      - released    
+
+env:
+  PY_VERSION: 3.11      
+
+jobs:
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v4.5.0
+        with:
+          python-version: $PY_VERSION
+          architecture: x64
+
+      - name: Checkout PyTorch
+        uses: actions/checkout@v3.3.0
+
+      - name: Install flake8
+        run: pip install flake8
+
+      - name: Run flake8
+        uses: suo/flake8-github-action@releases/v1
+        with:
+          checkName: 'flake8'   # NOTE: this needs to be the same as the job name
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [flake8]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["$PY_VERSION"]
+
+    steps:
+    - uses: actions/checkout@v3.3.0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4.5.0
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements_dev.txt; fi
+
+    - name: Test with pytest
+      run: |
+        pytest -vs test 
+ 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,15 +3,15 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Create and publish a Docker image
+name: Build
 
 on:
-  push:
-    branches:
-      - main
-  release:
+  workflow_run:
+    workflows: [Lint & Test Python package]
     types:
-      - released
+      - completed 
+    branches:
+      - main     
 
 env:
   REGISTRY: ghcr.io
@@ -25,8 +25,10 @@ jobs:
     permissions:
       packages: write
       contents: read
-
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - run: echo 'The lint & test workflow passed'
+
       - uses: actions/checkout@v2
 
       - name: Build image


### PR DESCRIPTION
Runs flake8 and pytest jobs in GitHu CI. 

Lint & Test Python package runs on all Push & Release events. 

Build workflow runs when Lint & Test Python package completes successfully on the main branch. (This should then pick up release events)