### PR TITLE
Typo on landing + update rules & openapi version #

### DIFF
--- a/app/bgs_rules.py
+++ b/app/bgs_rules.py
@@ -25,7 +25,7 @@ with open('app/gb_outline.geojson', 'wt') as outfile:
 
 GB_OUTLINE = Path(__file__).parent / 'gb_outline.geojson'
 NI_OUTLINE = Path(__file__).parent / 'ni_outline.geojson'
-bgs_rules_version = '2.0.0'
+bgs_rules_version = '3.0.0'
 
 
 def check_required_groups(tables: dict) -> List[dict]:

--- a/app/main.py
+++ b/app/main.py
@@ -83,7 +83,7 @@ def custom_openapi():
         return app.openapi_schema
     openapi_schema = get_openapi(
         title="pyagsapi - AGS File Utilities Tools and API",
-        version="2.0.0",
+        version="4.0.0",
         description=("The API performs schema validation, data validation and conversion of your AGS files. "
                      "Schema validation and conversion uses https://gitlab.com/ags-data-format-wg/ags-python-library"),
         routes=app.routes,

--- a/app/templates/landing_page.html
+++ b/app/templates/landing_page.html
@@ -90,9 +90,7 @@
     <form action="/validate/" enctype="multipart/form-data" method="post" id="validateForm">
         <br>
       <fieldset>
-          <legend><div class="tooltip">Select AGS Version, if "None" uses version specified in TRAN_AGS, if not present, uses v4.1.1. 
-            <span class="tooltiptext">Tool uses AGS version specified. If "None", validator uses version in the supplied file, if not present, uses v4.1.1</span>
-          </div></legend>
+          <legend>Select AGS Version - if "None", tool uses version specified in TRAN_AGS, if not specified, tool uses v4.1.1.</legend>
           <input type="radio" id="none" name="std_dictionary" value="" checked>
           <label for="none">None</label>
           <input type="radio" id="4.0.3" name="std_dictionary" value="v4_0_3">
@@ -140,7 +138,7 @@
     <br>
     <form action="/convert/" enctype="multipart/form-data" method="post" id="convertForm">
       <fieldset>
-        <legend><strong>.ags TO .xlsx only</strong> - sort worksheets in .xlsx file in alphabetical order (Warning: The original group order will be lost)</legend>
+        <legend>Sort worksheets in .xlsx file in alphabetical order <strong>(Warning: .ags to .xlsx only. The original group order will be lost)</strong></legend>
         <input type="radio" id="alpha" name="sort_tables" value="True">
         <label for="alpha">True</label>
         <input type="radio" id="default" name="sort_tables" value="False" checked>


### PR DESCRIPTION
Update bgs rules version to v3 and pyagsapi version stated in openapi as v4. 

Also minor typo on landing page re ags version selection