### PR TITLE
If AGS fails due to file errors don't do BGS checks

### DIFF
--- a/app/validation.py
+++ b/app/validation.py
@@ -67,8 +67,11 @@ def validate(filename: Path,
             except KeyError:
                 # No additional metadata
                 pass
+            can_proceed = result.pop('can_proceed')
             # Add remaining keys to response
             response.update(result)
+            if not can_proceed:
+                break
 
     error_count = len(reduce(lambda total, current: total + current, all_errors.values(), []))
     if error_count > 0:

--- a/test/fixtures_json.py
+++ b/test/fixtures_json.py
@@ -193,7 +193,7 @@ JSON_RESPONSES = {
                                           'group': '',
                                           'line': 1}]},
         'valid': False,
-        'additional_metadata': {}
+        'additional_metadata': {'AGS Error': 'Further checks unable to proceed due to file error, see errors'}
     },
     'real/Blackburn Southern Bypass.ags': {
         'filename': 'Blackburn Southern Bypass.ags',
@@ -604,7 +604,7 @@ JSON_RESPONSES = {
                                           'line': 1}]},
 
         'valid': False,
-        'additional_metadata': {}
+        'additional_metadata': {'AGS Error': 'Further checks unable to proceed due to file error, see errors'}
     },
     'extension_is.bad': {
         'filename': 'extension_is.bad',

--- a/test/unit/test_checkers.py
+++ b/test/unit/test_checkers.py
@@ -24,14 +24,13 @@ AGS_FILE_DATA = {
     ('nonsense.AGS', {'AGS Format Rule 2a', 'AGS Format Rule 3', 'AGS Format Rule 5', 'AGS Format Rule 13',
                       'AGS Format Rule 14', 'AGS Format Rule 15', 'AGS Format Rule 17'}),
     ('empty.ags', {'AGS Format Rule 13', 'AGS Format Rule 14', 'AGS Format Rule 15', 'AGS Format Rule 17'}),
-    ('real/A3040_03.ags', {'AGS Format Rule 3'}),
     ('real/43370.ags', {'AGS Format Rule 2a', 'AGS Format Rule 1'}),
-    ('real/JohnStPrimarySchool.ags', {'File read error'}),
-    ('real/19684.ags', {'AGS Format Rule 3'}),
-    ('real/E52A4379 (2).ags', {'AGS Format Rule 3'}),
 ])
 def test_check_ags(filename, expected_rules):
-    """Check that broken rules are returned and exceptions handled correctly."""
+    """
+       Check that broken rules are returned and exceptions handled correctly.
+       These file should return a True can_proceed flag.
+    """
     # Arrange
     filename = TEST_FILE_DIR / filename
 
@@ -42,6 +41,33 @@ def test_check_ags(filename, expected_rules):
     # Check that metadata fields are correct
     assert result['checker'] == f'python_ags4 v{python_ags4.__version__}'
     assert set(result['errors'].keys()) == expected_rules
+    assert result['can_proceed']
+
+
+@pytest.mark.parametrize('filename, expected_rules', [
+    ('real/A3040_03.ags', {'AGS Format Rule 3'}),
+    ('real/JohnStPrimarySchool.ags', {'File read error'}),
+    ('real/19684.ags', {'AGS Format Rule 3'}),
+    ('real/E52A4379 (2).ags', {'AGS Format Rule 3'}),
+])
+def test_check_ags_file_errors(filename, expected_rules):
+    """
+       Check that broken rules are returned and exceptions handled correctly.
+       These file should return additional metadata and a False can_proceed flag.
+    """
+    # Arrange
+    filename = TEST_FILE_DIR / filename
+
+    # Act
+    result = check_ags(filename)
+
+    # Assert
+    # Check that metadata fields are correct
+    assert result['checker'] == f'python_ags4 v{python_ags4.__version__}'
+    assert set(result['errors'].keys()) == expected_rules
+    assert not result['can_proceed']
+    assert result['additional_metadata']['AGS Error'] == ("Further checks unable to proceed"
+                                                          " due to file error, see errors")
 
 
 @pytest.mark.parametrize('filename, expected_rules, file_read_message', [

--- a/test/unit/test_validation.py
+++ b/test/unit/test_validation.py
@@ -15,12 +15,13 @@ TEST_FILE_DIR = Path(__file__).parent.parent / 'files'
 
 def mock_check_ags(filename, standard_AGS4_dictionary=None):
     return dict(checker='ags', dictionary='some_dict',
-                errors={})
+                errors={}, can_proceed=True)
 
 
 def mock_check_bgs(filename, **kwargs):
     return dict(checker='bgs',
-                errors={'BGS': [{}]})
+                errors={'BGS': [{}]},
+                can_proceed=True)
 
 
 @freeze_time(FROZEN_TIME)


### PR DESCRIPTION
The AGS checker will handle and report AGS3 files, however these cannot be read by the BGS checker. In this case the BGS tests should not happen. This PR adds a flag to the checker results to control this and adds additional metadata that could be used by the API consumer. Relevant tests have been revised.