### PR TITLE
WIP: Create Data Discovery Page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -77,6 +77,10 @@ app.mount("/static", StaticFiles(directory="app/static"), name="static")
 async def landing_page(request: Request):
     return templates.TemplateResponse('landing_page.html', {'request': request})
 
+@app.get("/datadiscovery", response_class=HTMLResponse, include_in_schema=False)
+async def datadiscovery(request: Request):
+    return templates.TemplateResponse('datadiscovery.html', {'request': request})
+
 
 def custom_openapi():
     if app.openapi_schema:

--- a/app/main.py
+++ b/app/main.py
@@ -77,6 +77,7 @@ app.mount("/static", StaticFiles(directory="app/static"), name="static")
 async def landing_page(request: Request):
     return templates.TemplateResponse('landing_page.html', {'request': request})
 
+
 @app.get("/datadiscovery", response_class=HTMLResponse, include_in_schema=False)
 async def datadiscovery(request: Request):
     return templates.TemplateResponse('datadiscovery.html', {'request': request})

--- a/app/templates/datadiscovery.html
+++ b/app/templates/datadiscovery.html
@@ -1,0 +1,39 @@
+{% extends "_base.html" %}
+{% block title %}Home{% endblock %}
+{% block body %}
+
+<br/>
+<section id="identification">
+    <h1>AGS4 File Utilities Tool and API</h1>
+    <br>
+    <p>This tool and associated <a href="/docs/">API</a> allow schema validation, data validation and conversion of your <a href="https://www.ags.org.uk/data-format/">AGS files</a>. Files are not saved or stored by this tool. Also included are links to our other AGS data related services and applications</p>
+    <h2>Tools and Utilities</h2>
+    <ul> 
+        <li><a href="/datadiscovery/">AGS Data Discovery</a></li>
+        <li><a href="/#deposit">AGS Data Submission</a></li>   
+        <li><a href="/#validator">AGS Schema & Data Validator</a></li>
+        <li><a href="/#converter">File Conversion .ags &#8596; .xlsx</a></li>
+        <li><a href="/#openapi">API Documentation</a></li>
+    </ul>
+</section>
+<br>
+<hr>
+<br>
+<section id="ags_data">
+  <h2>AGS Data Discovery</h2>
+  <br>
+  <p>Use the map below to find AGS data, click on the markers to find borehole information, links to graphical logs and the original submitted data.</p>
+  <p><b>The map will show a maximum of 100 AGS markers - users may need to pan/zoom to display markers of interest. </b></p>
+  <p><b>If no AGS Submission Record is shown at the link provided there is likely a legacy confidentiality restriction.</b></p>
+  <br>
+  <div id="mapid">
+    <!-- <div id="dOpacitySliderBox">
+        <div id="opacitySlider"></div>
+        <div class="dOpacitySliderLabel">Transparency</div>
+    </div>-->
+</div>
+</section> 
+<br>
+<br>
+
+{% endblock %}

--- a/app/templates/datadiscovery.html
+++ b/app/templates/datadiscovery.html
@@ -9,8 +9,8 @@
     <p>This tool and associated <a href="/docs/">API</a> allow schema validation, data validation and conversion of your <a href="https://www.ags.org.uk/data-format/">AGS files</a>. Files are not saved or stored by this tool. Also included are links to our other AGS data related services and applications</p>
     <h2>Tools and Utilities</h2>
     <ul> 
-        <li><a href="/datadiscovery/">AGS Data Discovery</a></li>
-        <li><a href="/#deposit">AGS Data Submission</a></li>   
+        <li><a href="/datadiscovery/">AGS Data Discovery</a> - Find AGS data, view/download scanned logs, download AGS files</li>
+        <li><a href="/#deposit">AGS Data Submission</a> - How to submit data to BGS</li>   
         <li><a href="/#validator">AGS Schema & Data Validator</a></li>
         <li><a href="/#converter">File Conversion .ags &#8596; .xlsx</a></li>
         <li><a href="/#openapi">API Documentation</a></li>

--- a/app/templates/landing_page.html
+++ b/app/templates/landing_page.html
@@ -9,8 +9,8 @@
     <p>This tool and associated <a href="/docs/">API</a> allow schema validation, data validation and conversion of your <a href="https://www.ags.org.uk/data-format/">AGS files</a>. Files are not saved or stored by this tool. Also included are links to our other AGS data related services and applications</p>
     <h2>Tools and Utilities</h2>
     <ul> 
-        <li><a href="/datadiscovery/">AGS Data Discovery</a></li>
-        <li><a href="#deposit">AGS Data Submission</a></li>   
+        <li><a href="/datadiscovery/">AGS Data Discovery</a> - Find AGS data, view/download scanned logs, download AGS files</li>
+        <li><a href="/#deposit">AGS Data Submission</a> - How to submit data to BGS</li>    
         <li><a href="#validator">AGS Schema & Data Validator</a></li>
         <li><a href="#converter">File Conversion .ags &#8596; .xlsx</a></li>
         <li><a href="#openapi">API Documentation</a></li>

--- a/app/templates/landing_page.html
+++ b/app/templates/landing_page.html
@@ -9,9 +9,9 @@
     <p>This tool and associated <a href="/docs/">API</a> allow schema validation, data validation and conversion of your <a href="https://www.ags.org.uk/data-format/">AGS files</a>. Files are not saved or stored by this tool. Also included are links to our other AGS data related services and applications</p>
     <h2>Tools and Utilities</h2>
     <ul> 
+        <li><a href="/datadiscovery/">AGS Data Discovery</a></li>
         <li><a href="#deposit">AGS Data Submission</a></li>   
         <li><a href="#validator">AGS Schema & Data Validator</a></li>
-        <li><a href="#ags_data">AGS Data Discovery</a></li>
         <li><a href="#converter">File Conversion .ags &#8596; .xlsx</a></li>
         <li><a href="#openapi">API Documentation</a></li>
     </ul>
@@ -136,23 +136,6 @@
       </fieldset>
     </form>
 </section>
-<br>
-<br>
-<br>
-<section id="ags_data">
-  <h2>AGS Data Discovery</h2>
-  <br>
-  <p>Use the map below to find AGS data, click on the markers to find borehole information, links to graphical logs and the original submitted data.</p>
-  <p><b>The map will show a maximum of 100 AGS markers - users may need to pan/zoom to display markers of interest. </b></p>
-  <p><b>If no AGS Submission Record is shown at the link provided there is likely a legacy confidentiality restriction.</b></p>
-  <br>
-  <div id="mapid">
-    <!-- <div id="dOpacitySliderBox">
-        <div id="opacitySlider"></div>
-        <div class="dOpacitySliderLabel">Transparency</div>
-    </div>-->
-</div>
-</section> 
 <br>
 <br>
 <br>


### PR DESCRIPTION
Landing page was getting long. 

To add the ags export functions it was felt the data discovery section should be on a seperate page