### PR TITLE
Export of boreholes by IDs and polygon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__
 venv
+.venv
 .idea
 .coverage
 htmlcov

--- a/app/errors.py
+++ b/app/errors.py
@@ -6,6 +6,7 @@ from app.schemas import Error, ErrorResponse
 
 # Define error responses
 error_responses = {
+    status.HTTP_400_BAD_REQUEST: {"model": ErrorResponse},
     status.HTTP_404_NOT_FOUND: {"model": ErrorResponse},
     status.HTTP_422_UNPROCESSABLE_ENTITY: {"model": ErrorResponse},
     status.HTTP_500_INTERNAL_SERVER_ERROR: {"model": ErrorResponse}

--- a/app/routes.py
+++ b/app/routes.py
@@ -398,7 +398,8 @@ def ags_export_by_polygon(polygon: str = polygon_query):
     :raises HTTPException 500: If the borehole exporter returns an error.
     """
 
-    # Check that the WKT is a valid POLYGON
+    # Check explicitly that the WKT is a valid POLYGON
+    # The BOREHOLE_INDEX_URL API does not return an error for some bad WKT
     check_df = gpd.GeoDataFrame([{"type": "zone", "bound": polygon}])
     try:
         gpd.GeoSeries.from_wkt(check_df['bound'])

--- a/app/routes.py
+++ b/app/routes.py
@@ -10,7 +10,6 @@ from fastapi import APIRouter, BackgroundTasks, File, Form, Query, Request, Uplo
 from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.exceptions import HTTPException
 
-import geopandas as gpd
 import shapely
 
 from requests.exceptions import Timeout, ConnectionError, HTTPError

--- a/app/routes.py
+++ b/app/routes.py
@@ -289,12 +289,12 @@ def prepare_validation_response(request, data):
             include_in_schema=True,
             response_class=Response,
             responses=pdf_responses)
-def get_ags_log(bgs_loca_id: int = ags_log_query,
+def get_ags_log(bgs_loca_id: str = ags_log_query,
                 response_type: ResponseType = response_type_query):
     """
     Get a graphical log (.pdf) for a single borehole in AGS format from the National Geoscience Data Centre.
     :param bgs_loca_id: The unique identifier of the borehole to generate the log for.
-    :type bgs_loca_id: int
+    :type bgs_loca_id: str
     :param response_type: The type of response to return (e.g. 'attachment' to force download or 'inline' \
     to display in browser).
     :type response_type: ResponseType, optional
@@ -338,11 +338,11 @@ def get_ags_log(bgs_loca_id: int = ags_log_query,
             include_in_schema=True,
             response_class=Response,
             responses=zip_ags_responses)
-def ags_export(bgs_loca_id: int = ags_export_query):
+def ags_export(bgs_loca_id: str = ags_export_query):
     """
     Export a single borehole in .ags format from AGS data held by the National Geoscience Data Centre.
     :param bgs_loca_id: The unique identifier of the borehole to export.
-    :type bgs_loca_id: int
+    :type bgs_loca_id: str
     :return: A response containing a .zip file with the exported borehole data.
     :rtype: Response
     :raises HTTPException 500: If the borehole exporter could not be reached.
@@ -431,10 +431,10 @@ def ags_export_by_polygon(polygon: str = polygon_query):
                             detail="No boreholes found in the given polygon")
     elif collection['numberMatched'] > 10:
         raise HTTPException(status_code=404,
-                            detail="More than 10 boreholes found in the given polygon. "
-                            "Please try with a smaller polygon")
+                            detail=f"More than 10 boreholes ({collection['numberMatched']}) "
+                            "found in the given polygon. Please try with a smaller polygon")
 
-    bgs_loca_ids = ':'.join([f['id'] for f in collection['features']])
+    bgs_loca_ids = ';'.join([f['id'] for f in collection['features']])
     url = BOREHOLE_EXPORT_URL.format(bgs_loca_id=bgs_loca_ids)
 
     try:

--- a/app/routes.py
+++ b/app/routes.py
@@ -369,8 +369,7 @@ def ags_export(bgs_loca_id: str = ags_export_query):
             raise HTTPException(status_code=500,
                                 detail="The borehole exporter returned an error.")
 
-    filename = f"{bgs_loca_id}.zip"
-    headers = {'Content-Disposition': f'attachment; filename="{filename}"'}
+    headers = {'Content-Disposition': 'attachment; filename="boreholes.zip"'}
 
     return Response(response.content, headers=headers, media_type='application/x-zip-compressed')
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -419,9 +419,8 @@ def ags_export_by_polygon(polygon: str = polygon_query,
 
     # Check explicitly that the WKT is a valid POLYGON
     # The BOREHOLE_INDEX_URL API does not return an error for some bad WKT
-    check_df = gpd.GeoDataFrame([{"type": "zone", "bound": polygon}])
     try:
-        gpd.GeoSeries.from_wkt(check_df['bound'])
+        shapely.wkt.loads(polygon)
     except shapely.errors.GEOSException:
         raise HTTPException(status_code=422,
                             detail="Invalid polygon")

--- a/app/routes.py
+++ b/app/routes.py
@@ -409,7 +409,7 @@ def ags_export_by_polygon(polygon: str = polygon_query,
     :rtype: Union[BoreholeCountResponse, Response]
     :return: A response containing a count or a .zip file with the exported borehole data.
     :rtype: Response
-    :raises HTTPException 404: If there are no boreholes or more than 10 boreholes in the polygon.
+    :raises HTTPException 400: If there are no boreholes or more than 10 boreholes in the polygon.
     :raises HTTPException 422: If the Well Known Text is not a POLYGON or is invalid.
     :raises HTTPException 500: If the borehole index could not be reached.
     :raises HTTPException 500: If the borehole index returns an error.
@@ -451,10 +451,10 @@ def ags_export_by_polygon(polygon: str = polygon_query,
         response = prepare_count_response(request, count)
     else:
         if count == 0:
-            raise HTTPException(status_code=404,
+            raise HTTPException(status_code=400,
                                 detail="No boreholes found in the given polygon")
         elif count > 10:
-            raise HTTPException(status_code=404,
+            raise HTTPException(status_code=400,
                                 detail=f"More than 10 boreholes ({count}) "
                                 "found in the given polygon. Please try with a smaller polygon")
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -293,7 +293,7 @@ async def convert(background_tasks: BackgroundTasks,
             summary="Generate Graphical Log",
             description=("Generate a graphical log (.pdf) from AGS data "
                          "held by the National Geoscience Data Centre."),
-            include_in_schema=True,
+            include_in_schema=False,
             response_class=Response,
             responses=pdf_responses)
 def get_ags_log(bgs_loca_id: str = ags_log_query,
@@ -342,7 +342,7 @@ def get_ags_log(bgs_loca_id: str = ags_log_query,
             summary="Export one or more boreholes in .ags format",
             description=("Export one or more borehole in .ags format from AGS data "
                          "held by the National Geoscience Data Centre."),
-            include_in_schema=True,
+            include_in_schema=False,
             response_class=Response,
             responses=ags_export_responses)
 def ags_export(bgs_loca_id: str = ags_export_query):
@@ -390,7 +390,7 @@ def ags_export(bgs_loca_id: str = ags_export_query):
             summary="Export a number of boreholes in .ags format",
             description=("Export a number of boreholes in .ags format from AGS data "
                          "held by the National Geoscience Data Centre."),
-            include_in_schema=True,
+            include_in_schema=False,
             response_model=BoreholeCountResponse,
             responses=ags_export_responses)
 def ags_export_by_polygon(polygon: str = polygon_query,

--- a/app/routes.py
+++ b/app/routes.py
@@ -18,6 +18,7 @@ from app.errors import error_responses, InvalidPayloadError
 from app.schemas import ValidationResponse
 
 BOREHOLE_VIEWER_URL = "https://gwbv.bgs.ac.uk/GWBV/viewborehole?loca_id={bgs_loca_id}"
+BOREHOLE_EXPORT_URL = "https://gwbv.bgs.ac.uk/ags_export/"
 
 router = APIRouter()
 
@@ -35,6 +36,11 @@ pdf_responses = dict(error_responses)
 pdf_responses['200'] = {
     "content": {"application/pdf": {}},
     "description": "Return a graphical log of AGS data in .PDF format"}
+
+zip_ags_responses = dict(error_responses)
+zip_ags_responses['200'] = {
+    "content": {"application/x-zip-compressed": {}},
+    "description": "Return a zip containing .ags file and metadata .txt file"}    
 
 
 # Enum for search logic
@@ -113,6 +119,13 @@ ags_log_query = Query(
     example="20190430093402523419",
 )
 
+ags_export_query = Query(
+    ...,
+    title="BGS LOCA ID",
+    description="BGS LOCA ID",
+    example="20190430093402523419",
+)
+
 response_type_query = Query(
     default=ResponseType.inline,
     title='PDF Response Type',
@@ -136,6 +149,26 @@ async def validate(background_tasks: BackgroundTasks,
     if not files[0].filename or not checkers:
         raise InvalidPayloadError(request)
 
+"""
+    Validate an AGS4 file to the AGS File Format v4.x rules and the NGDC data submission requirements.
+    Uses the Official AGS4 Python Library.
+    :param background_tasks: Background tasks for deleting temporary directories.
+    :type background_tasks: BackgroundTasks
+    :param files: List of AGS4 files to be validated.
+    :type files: List[UploadFile]
+    :param std_dictionary: The standard dictionary to use for validation. Options are "BGS" or "AGS".
+    :type std_dictionary: Dictionary
+    :param checkers: List of validation rules to be used during validation.
+    :type checkers: List[Checker]
+
+    :param fmt: The format to return the validation results in. Options are "text" or "json".
+    :type fmt: Format
+    :param request: The request object.
+    :type request: Request
+    :return: A response with the validation results in either plain text or JSON format.
+    :rtype: Union[FileResponse, ValidationResponse]
+    :raises InvalidPayloadError: If the payload is missing files or checkers.
+    """
     checkers = [checker_functions[c] for c in checkers]
 
     tmp_dir = Path(tempfile.mkdtemp())
@@ -167,6 +200,21 @@ async def validate(background_tasks: BackgroundTasks,
 
     return response
 
+    """
+    Convert files between .ags and .xlsx format. Option to sort worksheets in .xlsx file in alphabetical order.
+    :param background_tasks: A background task that manages file conversion asynchronously.
+    :type background_tasks: BackgroundTasks
+    :param files: A list of files to be converted. Must be in .ags or .xlsx format.
+    :type files: List[UploadFile]
+    :param sort_tables: A boolean indicating whether to sort worksheets in the .xlsx file in alphabetical order.
+    :type sort_tables: bool
+    :param request: The HTTP request object.
+    :type request: Request
+    :return: A streaming response containing a .zip file with the converted files and a log file.
+    :rtype: StreamingResponse
+    :raises InvalidPayloadError: If the request payload is invalid.
+    :raises Exception: If the conversion fails or an unexpected error occurs.
+    """
 
 @router.post("/convert/",
              tags=["convert"],
@@ -220,14 +268,27 @@ def prepare_validation_response(request, data):
 
 
 @router.get("/ags_log/",
-            # tags=["ags_log"],
-            # summary="Generate Graphical Log",
-            # description="Generate a graphical log (.pdf) from AGS data held by the National Geoscience Data Centre.",
-            include_in_schema=False,
+            tags=["ags_log"],
+            summary="Generate Graphical Log",
+            description="Generate a graphical log (.pdf) from AGS data held by the National Geoscience Data Centre.",
+            include_in_schema=True,
             response_class=Response,
             responses=pdf_responses)
 def get_ags_log(bgs_loca_id: int = ags_log_query,
                 response_type: ResponseType = response_type_query):
+    """
+    Get a graphical log (.pdf) for a single borehole in AGS format from the National Geoscience Data Centre.
+    :param bgs_loca_id: The unique identifier of the borehole to generate the log for.
+    :type bgs_loca_id: int
+    :param response_type: The type of response to return (e.g. 'attachment' to force download or 'inline' \
+    to display in browser).
+    :type response_type: ResponseType, optional
+    :return: A response containing a .pdf file with the generated borehole log.
+    :rtype: Response
+    :raises HTTPException 500: If the borehole generator could not be reached.
+    :raises HTTPException 404: If the specified borehole does not exist or is confidential.
+    :raises HTTPException 500: If the borehole generator returns an error.
+    """    
     url = BOREHOLE_VIEWER_URL.format(bgs_loca_id=bgs_loca_id)
 
     try:
@@ -251,3 +312,51 @@ def get_ags_log(bgs_loca_id: int = ags_log_query,
     headers = {'Content-Disposition': f'{response_type.value}; filename="{filename}"'}
 
     return Response(response.content, headers=headers, media_type='application/pdf')
+
+@router.post("/ags_export/",
+             tags=["ags_export"],
+             summary="Export a single borehole in .ags format",
+             description="Export a single borehole in .ags format from AGS data \
+             held by the National Geoscience Data Centre.",
+             include_in_schema=True,
+             response_class=StreamingResponse,
+             responses=zip_ags_responses)
+def post_ags_export(bgs_loca_id: int = ags_export_query):
+    """
+    Export a single borehole in .ags format from AGS data held by the National Geoscience Data Centre.
+    :param bgs_loca_id: The unique identifier of the borehole to export.
+    :type bgs_loca_id: int
+    :return: A streaming response containing a .zip file with the exported borehole data.
+    :rtype: StreamingResponse
+    :raises HTTPException 500: If the borehole exporter could not be reached.
+    :raises HTTPException 404: If the specified borehole does not exist or is confidential.
+    :raises HTTPException 500: If the borehole exporter returns an error.
+    """
+    url = BOREHOLE_EXPORT_URL
+    data = str(bgs_loca_id)
+    headers = {"Content-Type": "text/plain",
+               "Accept": "*/*",
+               "Accept-Encoding": "gzip, deflate, br",
+               "Connection": "keep-alive"}
+
+    try:
+        response = requests.post(url, data=data, headers=headers, timeout=10)
+    except (Timeout, ConnectionError):
+        raise HTTPException(status_code=500,
+                            detail="The borehole exporter could not be reached.  Please try again later.")
+
+    try:
+        response.raise_for_status()
+    except HTTPError:
+        if response.status_code == 404:
+            raise HTTPException(status_code=404,
+                                detail=f"Failed to retrieve borehole {bgs_loca_id}. "
+                                "It may not exist or may be confidential")
+        else:
+            raise HTTPException(status_code=500,
+                                detail="The borehole exporter returned an error.")
+
+    content = response.content
+    response = StreamingResponse(content, media_type="application/x-zip-compressed")
+    response.headers["Content-Disposition"] = f"attachment; filename={bgs_loca_id}.zip"
+    return response

--- a/app/routes.py
+++ b/app/routes.py
@@ -272,7 +272,8 @@ def prepare_validation_response(request, data):
 @router.get("/ags_log/",
             tags=["ags_log"],
             summary="Generate Graphical Log",
-            description="Generate a graphical log (.pdf) from AGS data held by the National Geoscience Data Centre.",
+            description=("Generate a graphical log (.pdf) from AGS data "
+                         "held by the National Geoscience Data Centre."),
             include_in_schema=True,
             response_class=Response,
             responses=pdf_responses)
@@ -318,13 +319,13 @@ def get_ags_log(bgs_loca_id: int = ags_log_query,
 
 
 @router.get("/ags_export/",
-             tags=["ags_export"],
-             summary="Export a single borehole in .ags format",
-             description="Export a single borehole in .ags format from AGS data \
-             held by the National Geoscience Data Centre.",
-             include_in_schema=True,
-             response_class=Response,
-             responses=zip_ags_responses)
+            tags=["ags_export"],
+            summary="Export a single borehole in .ags format",
+            description=("Export a single borehole in .ags format from AGS data "
+                         "held by the National Geoscience Data Centre."),
+            include_in_schema=True,
+            response_class=Response,
+            responses=zip_ags_responses)
 def ags_export(bgs_loca_id: int = ags_export_query):
     """
     Export a single borehole in .ags format from AGS data held by the National Geoscience Data Centre.

--- a/app/routes.py
+++ b/app/routes.py
@@ -127,7 +127,7 @@ ags_log_query = Query(
 ags_export_query = Query(
     ...,
     title="BGS LOCA ID",
-    description="BGS LOCA ID",
+    description="A single ID or multiple IDs separated by semicolons",
     example="20190430093402523419",
 )
 
@@ -332,8 +332,8 @@ def get_ags_log(bgs_loca_id: str = ags_log_query,
 
 @router.get("/ags_export/",
             tags=["ags_export"],
-            summary="Export a single borehole in .ags format",
-            description=("Export a single borehole in .ags format from AGS data "
+            summary="Export one or more boreholes in .ags format",
+            description=("Export one or more borehole in .ags format from AGS data "
                          "held by the National Geoscience Data Centre."),
             include_in_schema=True,
             response_class=Response,

--- a/app/routes.py
+++ b/app/routes.py
@@ -435,25 +435,6 @@ def ags_export_by_polygon(polygon: str = polygon_query):
 
     bgs_loca_ids = ';'.join([f['id'] for f in collection['features']])
     url = BOREHOLE_EXPORT_URL.format(bgs_loca_id=bgs_loca_ids)
+    response = ags_export(bgs_loca_ids)
 
-    try:
-        response = requests.get(url, timeout=10)
-    except (Timeout, ConnectionError):
-        raise HTTPException(status_code=500,
-                            detail="The borehole exporter could not be reached.  Please try again later.")
-
-    try:
-        response.raise_for_status()
-    except HTTPError:
-        if response.status_code == 404:
-            raise HTTPException(status_code=404,
-                                detail=f"Failed to retrieve boreholes {bgs_loca_ids}. "
-                                "They may not exist or may be confidential")
-        else:
-            raise HTTPException(status_code=500,
-                                detail="The borehole exporter returned an error.")
-
-    filename = "boreholes.zip"
-    headers = {'Content-Disposition': f'attachment; filename="{filename}"'}
-
-    return Response(response.content, headers=headers, media_type='application/x-zip-compressed')
+    return response

--- a/app/routes.py
+++ b/app/routes.py
@@ -221,6 +221,17 @@ async def validate(background_tasks: BackgroundTasks,
     return response
 
 
+def prepare_validation_response(request, data):
+    """Package the data into a Response schema object"""
+    response_data = {
+        'msg': f'{len(data)} files validated',
+        'type': 'success',
+        'self': str(request.url),
+        'data': data,
+    }
+    return ValidationResponse(**response_data, media_type="application/json")
+
+
 @router.post("/convert/",
              tags=["convert"],
              response_class=StreamingResponse,
@@ -275,17 +286,6 @@ async def convert(background_tasks: BackgroundTasks,
     response = StreamingResponse(zipped_stream, media_type="application/x-zip-compressed")
     response.headers["Content-Disposition"] = f"attachment; filename={RESULTS}.zip"
     return response
-
-
-def prepare_validation_response(request, data):
-    """Package the data into a Response schema object"""
-    response_data = {
-        'msg': f'{len(data)} files validated',
-        'type': 'success',
-        'self': str(request.url),
-        'data': data,
-    }
-    return ValidationResponse(**response_data, media_type="application/json")
 
 
 @router.get("/ags_log/",

--- a/app/routes.py
+++ b/app/routes.py
@@ -300,9 +300,9 @@ def get_ags_log(bgs_loca_id: str = ags_log_query,
     :type response_type: ResponseType, optional
     :return: A response containing a .pdf file with the generated borehole log.
     :rtype: Response
-    :raises HTTPException 500: If the borehole generator could not be reached.
     :raises HTTPException 404: If the specified borehole does not exist or is confidential.
     :raises HTTPException 500: If the borehole generator returns an error.
+    :raises HTTPException 500: If the borehole generator could not be reached.
     """
 
     url = BOREHOLE_VIEWER_URL.format(bgs_loca_id=bgs_loca_id)
@@ -345,10 +345,14 @@ def ags_export(bgs_loca_id: str = ags_export_query):
     :type bgs_loca_id: str
     :return: A response containing a .zip file with the exported borehole data.
     :rtype: Response
-    :raises HTTPException 500: If the borehole exporter could not be reached.
-    :raises HTTPException 404: If the specified borehole does not exist or is confidential.
+    :raises HTTPException 404: If the specified boreholes do not exist or are confidential.
+    :raises HTTPException 422: If more than 10 borehole IDs are supplied.
     :raises HTTPException 500: If the borehole exporter returns an error.
+    :raises HTTPException 500: If the borehole exporter could not be reached.
     """
+
+    if len(bgs_loca_id.split(';')) > 10:
+        raise HTTPException(status_code=422, detail="More than 10 borehole IDs.")
 
     url = BOREHOLE_EXPORT_URL.format(bgs_loca_id=bgs_loca_id)
 
@@ -391,7 +395,7 @@ def ags_export_by_polygon(polygon: str = polygon_query):
     :return: A response containing a .zip file with the exported borehole data.
     :rtype: Response
     :raises HTTPException 404: If there are no boreholes or more than 10 boreholes in the polygon.
-    :raises HTTPException 422: If the WEll Known Text is not a POLYGON or is invalid.
+    :raises HTTPException 422: If the Well Known Text is not a POLYGON or is invalid.
     :raises HTTPException 500: If the borehole index could not be reached.
     :raises HTTPException 500: If the borehole index returns an error.
     :raises HTTPException 500: If the borehole exporter could not be reached.

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -72,3 +72,7 @@ class ErrorResponse(MinimalResponse):
 
 class ValidationResponse(MinimalResponse):
     data: List[Union[Validation, bool]] = None
+
+
+class BoreholeCountResponse(MinimalResponse):
+    count: int = Field(..., example=4)

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -71,8 +71,8 @@ var agsboreholes = L.featureGroup
             "<b>Project Engineer: </b>" + properties.proj_eng + "<br>" +
             "<b>Project Contractor: </b>" + properties.proj_cont + "<br>" +
             "<b>Original LOCA ID: </b>" + properties.loca_id + "<br>" +
-            "<b>AGS Graphical Log: </b>" + "<a href=" + "https://agsapi.bgs.ac.uk/ags_log/?bgs_loca_id=" + properties.bgs_loca_id + " target=" + "_blank" + ">View</a> / " +"<a href=" + "https://agsapi.bgs.ac.uk/ags_log/?bgs_loca_id=" + properties.bgs_loca_id + "&response_type=attachment" + ">Download</a>" + "<br>" +
-            // "<b>AGS Data: </b>" + "<a href=" + "https://agsapi.bgs.ac.uk/ags_export/?bgs_loca_id=" + properties.bgs_loca_id + " target=" + "_blank" + ">Download</a>" + "<br>" +
+            "<b>AGS Graphical Log: </b>" + "<a href=" + "/ags_log/?bgs_loca_id=" + properties.bgs_loca_id + " target=" + "_blank" + ">View</a> / " +"<a href=" + "/ags_log/?bgs_loca_id=" + properties.bgs_loca_id + "&response_type=attachment" + ">Download</a>" + "<br>" +
+            "<b>AGS Data (NGDC Download Service): </b>" + "<a href=" + "/ags_export/?bgs_loca_id=" + properties.bgs_loca_id + " target=" + "_blank" + ">Download</a>" + "<br>" +
             "<b>AGS Submission Record (raw data): </b>" + "<a href=" + properties.dad_item_url + " target=" + "_blank" + ">View</a>" + "<br>";
         layer.bindPopup(popupContent);
     },

--- a/app/templates/landing_page.html
+++ b/app/templates/landing_page.html
@@ -142,7 +142,7 @@
 <section id="ags_data">
   <h2>AGS Data Discovery</h2>
   <br>
-  <p>Use the map below to find AGS data, click on the markers to find borehole information, links to graphical logs and the original submitted data.</p>
+  <p>Use the map below to find AGS data, click on the markers to find borehole information, links to graphical logs, <a href="https://www.bgs.ac.uk/technologies/geotechnical-data-services/ags-download-service/">.ags data download from the NGDC AGS database,</a> and the original submitted AGS data.</p>
   <p><b>The map will show a maximum of 100 AGS markers - users may need to pan/zoom to display markers of interest. </b></p>
   <p><b>If no AGS Submission Record is shown at the link provided there is likely a legacy confidentiality restriction.</b></p>
   <br>

--- a/app/templates/landing_page.html
+++ b/app/templates/landing_page.html
@@ -31,7 +31,7 @@
     <br>
     <h3>AGS4 Validation </h3>
       <p>Performs validation using the <a href="https://gitlab.com/ags-data-format-wg/ags-python-library.">Official AGS Python Library</a> <strong>version 0.4.1</strong>, this implements checks of the rules as written in the <strong>AGS data format standard v4.x.</strong></p>
-      <p style="color:red">If your using AGS Data Format Standard v3.x use our legacy <a href="https://webapps.bgs.ac.uk/data/ags/validation/index.cfm">AGS Validator</a></p>
+      <p style="color:red">If you're using AGS Data Format Standard v3.x use our legacy <a href="https://webapps.bgs.ac.uk/data/ags/validation/index.cfm">AGS Validator</a></p>
     <br>
     <h3>BGS Data Validation</h3>
       <p>Your files will be validated against the below rules as defined by BGS/NGDC.</p>

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -614,14 +614,15 @@ def test_get_ags_exporter_error(client, monkeypatch):
     assert body['errors'][0]['desc'] == 'The borehole exporter returned an error.'
 
 
+@pytest.mark.xfail(IN_GITHUB_ACTIONS, reason="Upstream URL not available from Github Actions")
 def test_get_ags_exporter_by_polygon(client):
     # Arrange
     # There should be 4 boreholes within 2 projects in this area
     polygon = 'POLYGON((-3.946 56.063,-3.640 56.063,-3.640 55.966,-3.946 55.966,-3.946 56.063))'
     query = f'/ags_export_by_polygon/?polygon={polygon}'
-    # Define the borehole and project IDs and zipped AGS file to use for the test
+    # Define the expected borehole and project IDs and zipped AGS file to use for the test
     bgs_loca_ids = ['20200205093727287903', '20200205093728297906', '20200205093728297908', '20200205093728297910']
-    bgs_proj_ids = {id_[:16] for id_ in bgs_loca_ids}
+    bgs_proj_ids = {id_[:16] for id_ in bgs_loca_ids}  # unique ids when truncated to 16 digits
     ags_file_names = {f'{id_}.ags' for id_ in bgs_proj_ids}
     ags_metadata_file_name = 'FILE/BGSFileSet01/BGS_download_metadata.txt'
 

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -414,7 +414,7 @@ async def test_validate_dictionary_choice(async_client, dictionary, filename, ex
     ('attachment', 'attachment'),
     (None, 'inline')  # Defaults to 'inline'
 ])
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Upstream URL not avilable from Github Actions")
+@pytest.mark.xfail(IN_GITHUB_ACTIONS, reason="Upstream URL not available from Github Actions")
 def test_get_ags_log(client, response_type, response_type_result):
     """
     Confirm that the endpoint can return the expected .pdf.
@@ -440,7 +440,7 @@ def test_get_ags_log(client, response_type, response_type_result):
     assert response.content.startswith(b'%PDF')
 
 
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Upstream URL not avilable from Github Actions")
+@pytest.mark.xfail(IN_GITHUB_ACTIONS, reason="Upstream URL not available from Github Actions")
 def test_get_ags_log_unknown_borehole(client):
     """
     Confirm that the endpoint can return the expected error when an unknown bgs_loca_id is submitted.
@@ -506,7 +506,7 @@ def test_get_ags_log_generator_error(client, monkeypatch):
     assert body['errors'][0]['desc'] == 'The borehole generator returned an error.'
 
 
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Upstream URL not avilable from Github Actions")
+@pytest.mark.xfail(IN_GITHUB_ACTIONS, reason="Upstream URL not available from Github Actions")
 def test_get_ags_export(client, tmp_path):
     """
     Confirm that the endpoint can return the expected .zip.
@@ -540,7 +540,7 @@ def test_get_ags_export(client, tmp_path):
             assert tables['PROJ']['BGS_PROJ_ID'][0] == bgs_proj_id
 
 
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Upstream URL not avilable from Github Actions")
+@pytest.mark.xfail(IN_GITHUB_ACTIONS, reason="Upstream URL not available from Github Actions")
 def test_get_ags_export_unknown_borehole(client):
     """
     Confirm that the endpoint can return the expected error when an unknown bgs_loca_id is submitted.

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -526,7 +526,7 @@ def test_get_ags_export(client, tmp_path):
 
     # Assert
     assert response.status_code == 200
-    assert response.headers["Content-Disposition"] == f'attachment; filename="{bgs_loca_id}.zip"'
+    assert response.headers["Content-Disposition"] == 'attachment; filename="boreholes.zip"'
     assert response.headers["Content-Type"] == "application/x-zip-compressed"
     assert len(response.content) > 0
 

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -744,7 +744,7 @@ def test_get_ags_exporter_by_polygon_too_many_boreholes(client):
         response = ac.get(query)
 
     # Assert
-    assert response.status_code == 404
+    assert response.status_code == 400
     body = response.json()
     assert body['errors'][0]['desc'] == ('More than 10 boreholes (28) found in the given polygon. '
                                          'Please try with a smaller polygon')
@@ -760,7 +760,7 @@ def test_get_ags_exporter_by_polygon_no_boreholes(client):
         response = ac.get(query)
 
     # Assert
-    assert response.status_code == 404
+    assert response.status_code == 400
     body = response.json()
     assert body['errors'][0]['desc'] == 'No boreholes found in the given polygon'
 

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -674,11 +674,15 @@ def test_get_ags_exporter_error(client, monkeypatch):
 
 
 @pytest.mark.xfail(IN_GITHUB_ACTIONS, reason="Upstream URL not available from Github Actions")
-def test_get_ags_exporter_by_polygon(client):
+@pytest.mark.parametrize('count_only', [None, False])
+def test_get_ags_exporter_by_polygon(client, count_only):
     # Arrange
     # There should be 4 boreholes within 2 projects in this area
     polygon = 'POLYGON((-3.946 56.063,-3.640 56.063,-3.640 55.966,-3.946 55.966,-3.946 56.063))'
+
     query = f'/ags_export_by_polygon/?polygon={polygon}'
+    if count_only is not None:
+        query += '&count_only=False'
     # Define the expected borehole and project IDs and zipped AGS file to use for the test
     bgs_loca_ids = ['20200205093727287903', '20200205093728297906', '20200205093728297908', '20200205093728297910']
     bgs_proj_ids = {id_[:16] for id_ in bgs_loca_ids}  # unique ids when truncated to 16 digits

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -607,6 +607,26 @@ def test_get_ags_export_unknown_borehole(client):
     assert body['errors'][0]['desc'] == 'Failed to retrieve borehole 0. It may not exist or may be confidential'
 
 
+def test_get_ags_export_too_many_borehole_ids(client):
+    """
+    Confirm that an error is returned when bgs_loca_id comprises more than 10 IDs.
+    """
+    # Arrange
+    # Define the borehole IDs to use for the test
+    bgs_loca_ids = ['20200205093728297908'] * 11
+    bgs_loca_ids = ';'.join(bgs_loca_ids)
+    query = f'/ags_export/?bgs_loca_id={bgs_loca_ids}'
+
+    # Act
+    with client as ac:
+        response = ac.get(query)
+
+    # Assert
+    assert response.status_code == 422
+    body = response.json()
+    assert body['errors'][0]['desc'] == 'More than 10 borehole IDs.'
+
+
 def test_get_ags_exporter_unreachable(client, monkeypatch):
     # Arrange
     bgs_loca_id = 0

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -26,11 +26,17 @@ TEST_FILE_DIR = Path(__file__).parent.parent / 'files'
 
 
 def test_openapi_json(client):
-    """A hello-world type test to confirm testing framework works."""
+    """ Check that the openapi is accessible and it display the correct endpoints """
     response = client.get('/openapi.json')
     assert response.status_code == 200
     assert response.headers['content-type'] == 'application/json'
+    # exposed endpoints
     assert '/validate' in response.text
+    assert '/convert' in response.text
+    # hidden endpoints
+    assert '/ags_log' not in response.text
+    assert '/ags_export' not in response.text
+    assert '/ags_export_by_polygon' not in response.text
 
 
 @pytest.mark.parametrize('filename, expected',

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -1,5 +1,6 @@
 """Tests for API responses."""
 from io import BytesIO
+import os
 from pathlib import Path
 import shutil
 import zipfile
@@ -20,6 +21,7 @@ from test.fixtures import (BAD_FILE_DATA, DICTIONARIES, FROZEN_TIME,
 from test.fixtures_json import JSON_RESPONSES
 from test.fixtures_plain_text import PLAIN_TEXT_RESPONSES
 
+IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 TEST_FILE_DIR = Path(__file__).parent.parent / 'files'
 
 
@@ -417,7 +419,8 @@ async def test_validate_dictionary_choice(async_client, dictionary, filename, ex
     ('attachment', 'attachment'),
     (None, 'inline')  # Defaults to 'inline'
 ])
-def test_get_ags_log(client, monkeypatch, response_type, response_type_result):
+@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Upstream URL not avilable from Github Actions")
+def test_get_ags_log(client, response_type, response_type_result):
     """
     Confirm that the endpoint can return the expected .pdf.
     """
@@ -425,9 +428,6 @@ def test_get_ags_log(client, monkeypatch, response_type, response_type_result):
     # Define the borehole ID to use for the test
     bgs_loca_id = 20190430093402523419
     query = f'/ags_log/?bgs_loca_id={bgs_loca_id}'
-    # Patch the Borehole Viewer to be something that cannot be reached
-    monkeypatch.setattr(app_routes, "BOREHOLE_VIEWER_URL",
-                        'https://webservices.bgs.ac.uk/GWBV/viewborehole?loca_id={bgs_loca_id}')
 
     if response_type:
         query += f'&response_type={response_type}'
@@ -450,7 +450,8 @@ def test_get_ags_log(client, monkeypatch, response_type, response_type_result):
     assert response.content.startswith(b'%PDF')
 
 
-def test_get_ags_log_unknown_borehole(client, monkeypatch):
+@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Upstream URL not avilable from Github Actions")
+def test_get_ags_log_unknown_borehole(client):
     """
     Confirm that the endpoint can return the expected error when an unknown bgs_loca_id is submitted.
     """
@@ -458,9 +459,6 @@ def test_get_ags_log_unknown_borehole(client, monkeypatch):
     # Define the borehole ID to use for the test
     bgs_loca_id = 0
     query = f'/ags_log/?bgs_loca_id={bgs_loca_id}'
-    # Patch the Borehole Viewer to be something that cannot be reached
-    monkeypatch.setattr(app_routes, "BOREHOLE_VIEWER_URL",
-                        'https://webservices.bgs.ac.uk/GWBV/viewborehole?loca_id={bgs_loca_id}')
 
     # Act
     with client as ac:
@@ -519,7 +517,8 @@ def test_get_ags_log_generator_error(client, monkeypatch):
     assert body['errors'][0]['desc'] == 'The borehole generator returned an error.'
 
 
-def test_get_ags_export(client, monkeypatch):
+@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Upstream URL not avilable from Github Actions")
+def test_get_ags_export(client):
     """
     Confirm that the endpoint can return the expected .zip.
     """
@@ -546,7 +545,8 @@ def test_get_ags_export(client, monkeypatch):
     assert zipfile.is_zipfile(BytesIO(response.content))
 
 
-def test_get_ags_export_unknown_borehole(client, monkeypatch):
+@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Upstream URL not avilable from Github Actions")
+def test_get_ags_export_unknown_borehole(client):
     """
     Confirm that the endpoint can return the expected error when an unknown bgs_loca_id is submitted.
     """

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -614,6 +614,24 @@ def test_get_ags_exporter_error(client, monkeypatch):
     assert body['errors'][0]['desc'] == 'The borehole exporter returned an error.'
 
 
+@pytest.mark.parametrize('polygon', [
+    'NOTPOLYGON((0 0, 0 1, 1 1, 1 0, 0 0))',
+    'POLYGON((0 0, 0 1, 1 1, 1 0))'
+])
+def test_get_ags_exporter_by_polygon_not_polygon(client, polygon):
+    # Arrange
+    query = f'/ags_export_by_polygon/?polygon={polygon}'
+
+    # Act
+    with client as ac:
+        response = ac.get(query)
+
+    # Assert
+    assert response.status_code == 422
+    body = response.json()
+    assert body['errors'][0]['desc'] == 'Invalid polygon'
+
+
 @pytest.fixture(scope="function")
 def client():
     return TestClient(app)

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -432,16 +432,11 @@ def test_get_ags_log(client, response_type, response_type_result):
         response = ac.get(query)
 
     # Assert
-    # Check that the response status code is 200
     assert response.status_code == 200
-    # Check that the response headers include the correct Content-Disposition header
     content_disposition = f'{response_type_result}; filename="{bgs_loca_id}_log.pdf"'
     assert response.headers["Content-Disposition"] == content_disposition
-    # Check that the response media type is "application/pdf"
     assert response.headers["Content-Type"] == "application/pdf"
-    # Check that the response content is not empty
     assert len(response.content) > 0
-    # Check it is a PDF file
     assert response.content.startswith(b'%PDF')
 
 
@@ -460,7 +455,6 @@ def test_get_ags_log_unknown_borehole(client):
         response = ac.get(query)
 
     # Assert
-    # Check that the response status code is 404
     assert response.status_code == 404
     body = response.json()
     assert body['errors'][0]['desc'] == 'Failed to retrieve borehole 0. It may not exist or may be confidential'
@@ -530,19 +524,13 @@ def test_get_ags_export(client, tmp_path):
         response = ac.get(query)
 
     # Assert
-    # Check that the response status code is 200
     assert response.status_code == 200
-    # Check that the response headers include the correct Content-Disposition header
-    content_disposition = f'attachment; filename="{bgs_loca_id}.zip"'
-    assert response.headers["Content-Disposition"] == content_disposition
-    # Check that the response media type is "application/x-zip-compressed"
+    assert response.headers["Content-Disposition"] == f'attachment; filename="{bgs_loca_id}.zip"'
     assert response.headers["Content-Type"] == "application/x-zip-compressed"
-    # Check that the response content is not empty
     assert len(response.content) > 0
-    # Check it is a ZIP file
+
     assert zipfile.is_zipfile(BytesIO(response.content))
     with zipfile.ZipFile(BytesIO(response.content)) as ags_zip:
-        # The filename in the zip is truncated to 16 characters. A better test would be:
         assert ags_file_name in ags_zip.namelist()
         with ags_zip.open(ags_file_name) as ags_file:
             unzipped_file = tmp_path / 'test.ags'
@@ -567,7 +555,6 @@ def test_get_ags_export_unknown_borehole(client):
         response = ac.get(query)
 
     # Assert
-    # Check that the response status code is 404
     assert response.status_code == 404
     body = response.json()
     assert body['errors'][0]['desc'] == 'Failed to retrieve borehole 0. It may not exist or may be confidential'

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -707,6 +707,28 @@ def test_get_ags_exporter_by_polygon(client):
                 assert f'Project : {bgs_proj_id}' in metadata_text
 
 
+@pytest.mark.parametrize('polygon, count', [
+    ('POLYGON((-3.946 56.061,-3.640 56.061,-3.640 55.966,-3.946 55.966,-3.946 56.061))', 0),
+    ('POLYGON((-3.946 56.063,-3.640 56.063,-3.640 55.966,-3.946 55.966,-3.946 56.063))', 4),
+    ('POLYGON((-3.946 56.065,-3.640 56.065,-3.640 55.966,-3.946 55.966,-3.946 56.065))', 28),
+])
+def test_get_ags_exporter_by_polygon_count_only(client, polygon, count):
+    # Arrange
+    query = f'/ags_export_by_polygon/?polygon={polygon}&count_only=True'
+
+    # Act
+    with client as ac:
+        response = ac.get(query)
+
+    # Assert
+    assert response.status_code == 200
+    body = response.json()
+    assert body['msg'] == 'Borehole count'
+    assert body['type'] == 'success'
+    assert body['self'] is not None
+    assert body['count'] == count
+
+
 def test_get_ags_exporter_by_polygon_too_many_boreholes(client):
     # Arrange
     # There should be 28 boreholes in this area


### PR DESCRIPTION
This PR closes #99 providing two endpoints:
 - `/ags_export/?bgs_loca_id=` that will export a zip containing one or more multiple boreholes, with maximum of 10, and associated metadata by id
 - `/ags_export_by_polygon/?polygon=` that will export a zip containing one or more boreholes, with maximum of 10, and associated metadata of those boreholes found in the polygon described by Well Known Text.

All the tests should all pass locally. A number of integration tests are expected to expected to fail using github actions while the upstream endpoint is not externally available.

Using an internally deployed server check that `ags_export`:
- [x] returns a zip for a known `bgs_loca_id`
- [x] returns a zip for a list known IDs: `bgs_loca_id1;bgs_loca_id3;bgs_loca_id3`
- [x] returns errors for unknown IDs or a string of more than 10 IDs

And check that `ags_export_by_polygon`:
- [x] returns a json response containing a count of the number of boreholes in a polygon when `&count_only=True` is added
- [x] returns a zip for a WKT polygon containing 10 or fewer boreholes
- [x] returns errors for empty polygons, polygons with more than 10 boreholes and badly formed WKT

See the tests for some example cases.