### PR TITLE
Add ags download link to popup & update landing

### DIFF
--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -71,8 +71,8 @@ var agsboreholes = L.featureGroup
             "<b>Project Engineer: </b>" + properties.proj_eng + "<br>" +
             "<b>Project Contractor: </b>" + properties.proj_cont + "<br>" +
             "<b>Original LOCA ID: </b>" + properties.loca_id + "<br>" +
-            "<b>AGS Graphical Log: </b>" + "<a href=" + "https://agsapi.bgs.ac.uk/ags_log/?bgs_loca_id=" + properties.bgs_loca_id + " target=" + "_blank" + ">View</a> / " +"<a href=" + "https://agsapi.bgs.ac.uk/ags_log/?bgs_loca_id=" + properties.bgs_loca_id + "&response_type=attachment" + ">Download</a>" + "<br>" +
-            // "<b>AGS Data: </b>" + "<a href=" + "https://agsapi.bgs.ac.uk/ags_export/?bgs_loca_id=" + properties.bgs_loca_id + " target=" + "_blank" + ">Download</a>" + "<br>" +
+            "<b>AGS Graphical Log: </b>" + "<a href=" + "/ags_log/?bgs_loca_id=" + properties.bgs_loca_id + " target=" + "_blank" + ">View</a> / " +"<a href=" + "/ags_log/?bgs_loca_id=" + properties.bgs_loca_id + "&response_type=attachment" + ">Download</a>" + "<br>" +
+            "<b>AGS Data (NGDC Download Service): </b>" + "<a href=" + "/ags_export/?bgs_loca_id=" + properties.bgs_loca_id + " target=" + "_blank" + ">Download</a>" + "<br>" +
             "<b>AGS Submission Record (raw data): </b>" + "<a href=" + properties.dad_item_url + " target=" + "_blank" + ">View</a>" + "<br>";
         layer.bindPopup(popupContent);
     },

--- a/app/templates/landing_page.html
+++ b/app/templates/landing_page.html
@@ -142,7 +142,7 @@
 <section id="ags_data">
   <h2>AGS Data Discovery</h2>
   <br>
-  <p>Use the map below to find AGS data, click on the markers to find borehole information, links to graphical logs and the original submitted data.</p>
+  <p>Use the map below to find AGS data, click on the markers to find borehole information, links to graphical logs, <a href="https://www.bgs.ac.uk/technologies/geotechnical-data-services/ags-download-service/">.ags data download from the NGDC AGS database,</a> and the original submitted AGS data.</p>
   <p><b>The map will show a maximum of 100 AGS markers - users may need to pan/zoom to display markers of interest. </b></p>
   <p><b>If no AGS Submission Record is shown at the link provided there is likely a legacy confidentiality restriction.</b></p>
   <br>


### PR DESCRIPTION
Add download href to leaflet popup calling the new ags_export endpoint. 

Including landing page text update to highlight download of .ags is possible. 