### PR TITLE
Update fastapi & starlette; return https in external responses

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -112,7 +112,7 @@ app.openapi = custom_openapi
 
 @app.middleware("http")
 async def log_requests(request: Request, call_next):
-    if not request.client.host.startswith('10.'):
+    if request.client and not request.client.host.startswith('10.'):
         logger = logging.getLogger('request')
         logger.info(f"called by {request.client.host}")
         req_id = shortuuid.ShortUUID().random(length=8)
@@ -122,7 +122,7 @@ async def log_requests(request: Request, call_next):
 
     response = await call_next(request)
 
-    if not request.client.host.startswith('10.'):
+    if request.client and not request.client.host.startswith('10.'):
         call_time = int((time.time() - start_time) * 1000)
         logger.info(f"Request: id: {req_id} status: {response.status_code}, time: {call_time} ms")
         logger.debug(f"Request: id: {req_id} response headers: {response.headers}")

--- a/requirements.in
+++ b/requirements.in
@@ -10,9 +10,9 @@ python-ags4==0.5.0
 requests
 shortuuid
 # These libraries are already in FastAPI container but need updated
-fastapi==0.88.0
+fastapi==0.110.0
 h11==0.14.0
 pydantic==1.10.14
 python-multipart==0.0.9
-starlette==0.22.0
+starlette==0.36.3
 uvicorn==0.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ defusedxml==0.7.1
     # via python-ags4
 et-xmlfile==1.1.0
     # via openpyxl
-fastapi==0.88.0
+fastapi==0.110.0
     # via -r requirements.in
 fiona==1.9.5
     # via
@@ -106,12 +106,14 @@ six==1.16.0
     #   python-dateutil
 sniffio==1.3.1
     # via anyio
-starlette==0.22.0
+starlette==0.36.3
     # via
     #   -r requirements.in
     #   fastapi
 typing-extensions==4.10.0
-    # via pydantic
+    # via
+    #   fastapi
+    #   pydantic
 tzdata==2024.1
     # via pandas
 urllib3==2.2.1


### PR DESCRIPTION
This merge request updates two dependencies, pinning fastapi to 0.110.0 and starlette to 0.36.3.

It also ensures responses contain `https:` in the `self` field is in the environment `AGS_API_ENV` is set to 'PRODUCTION'. If the variable is missing or set to any other value the response will contain `http:`

