### PR TITLE
Upgrade to python-ags4 to v1.1.0

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -14,7 +14,7 @@ VALID_KEYS = [
     'AGS Format Rule 11a', 'AGS Format Rule 11b', 'AGS Format Rule 11c', 'AGS Format Rule 12',
     'AGS Format Rule 13', 'AGS Format Rule 14', 'AGS Format Rule 15', 'AGS Format Rule 16',
     'AGS Format Rule 17', 'AGS Format Rule 18', 'AGS Format Rule 19', 'AGS Format Rule 19a',
-    'AGS Format Rule 19b', 'AGS Format Rule 20', 'AGS Format Rule ?', 'General',
+    'AGS Format Rule 19b', 'AGS Format Rule 20', 'General', 'Validator Process Error',
     # Warnings and FYIs
     'Warning (Related to Rule 16)', 'FYI (Related to Rule 1)',
     # Errors

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ colorlog
 geopandas[all]
 numpy
 geojson-pydantic
-python-ags4==0.5.0
+python-ags4==1.1.0
 requests
 shortuuid
 fastapi[standard]

--- a/requirements.txt
+++ b/requirements.txt
@@ -159,7 +159,7 @@ pyparsing==3.2.3
     # via matplotlib
 pyproj==3.7.1
     # via geopandas
-python-ags4==0.5.0
+python-ags4==1.1.0
     # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via

--- a/test/fixtures_json.py
+++ b/test/fixtures_json.py
@@ -25,7 +25,7 @@ JSON_RESPONSES = {
         "checkers": ["python_ags4 v1.1.0"],
         'dictionary': 'Standard_dictionary_v4_1_1.ags',
         'time': dt.datetime(2021, 8, 23, 14, 25, 43, tzinfo=dt.timezone.utc),
-        "message": "13 error(s) found in file!",
+        "message": "14 error(s) found in file!",
         "errors": {
             "AGS Format Rule 4": [
                 {
@@ -93,7 +93,14 @@ JSON_RESPONSES = {
                     "desc": "Does not start with a valid data descriptor."
                 }
             ],
-            "AGS Format Rule ?": [
+            'General': [
+                {
+                    'desc': 'Could not complete validation. Please fix listed errors and try again.',
+                    'group': '',
+                    'line': '-',
+                },
+            ],
+            'Validator Process Error': [
                 {
                     "line": "-",
                     "group": "",
@@ -308,13 +315,17 @@ JSON_RESPONSES = {
         'checkers': ['python_ags4 v1.1.0'],
         'dictionary': 'Standard_dictionary_v4_1_1.ags',
         'time': dt.datetime(2021, 8, 23, 14, 25, 43, tzinfo=dt.timezone.utc),
-        'message': '1 error(s) found in file!',
+        'message': '2 error(s) found in file!',
         'errors': {'AGS Format Rule 3': [{'desc': 'Line starts with "**PROJ" instead '
                                           'of a valid data descriptor. This '
                                           'indicates that file is in the AGS3 '
                                           'format which is not supported.',
                                           'group': '',
-                                          'line': 1}]},
+                                          'line': 1}],
+                   'Validator Process Error': [{'desc': 'Validation terminated due to suspected '
+                                                'AGS3 file. Please fix errors and try again.',
+                                                'group': '',
+                                                'line': '-'}]},
         'valid': False,
         'additional_metadata': {},
         'geojson': {},
@@ -726,13 +737,17 @@ JSON_RESPONSES = {
         'checkers': ['python_ags4 v1.1.0'],
         'dictionary': 'Standard_dictionary_v4_1_1.ags',
         'time': dt.datetime(2021, 8, 23, 14, 25, 43, tzinfo=dt.timezone.utc),
-        'message': '1 error(s) found in file!',
+        'message': '2 error(s) found in file!',
         'errors': {'AGS Format Rule 3': [{'desc': 'Line starts with "**PROJ" instead '
                                           'of a valid data descriptor. This '
                                           'indicates that file is in the AGS3 '
                                           'format which is not supported.',
                                           'group': '',
-                                          'line': 1}]},
+                                          'line': 1}],
+                   'Validator Process Error': [{'desc': 'Validation terminated due to suspected '
+                                                'AGS3 file. Please fix errors and try again.',
+                                                'group': '',
+                                                'line': '-'}]},
 
         'valid': False,
         'additional_metadata': {},
@@ -898,7 +913,14 @@ GEOJSON_RESPONSES = {
                     "desc": "Does not start with a valid data descriptor."
                 }
             ],
-            "AGS Format Rule ?": [
+            'General': [
+                {
+                    'desc': 'Could not complete validation. Please fix listed errors and try again.',
+                    'group': '',
+                    'line': '-',
+                },
+            ],
+            'Validator Process Error': [
                 {
                     "line": "-",
                     "group": "",

--- a/test/fixtures_json.py
+++ b/test/fixtures_json.py
@@ -4,7 +4,7 @@ JSON_RESPONSES = {
     'example_ags.ags': {
         'filename': 'example_ags.ags',
         'filesize': 4105,
-        'checkers': ['python_ags4 v0.5.0'],
+        'checkers': ['python_ags4 v1.1.0'],
         'dictionary': 'Standard_dictionary_v4_1_1.ags',
         'time': dt.datetime(2021, 8, 23, 14, 25, 43, tzinfo=dt.timezone.utc),
         'message': 'All checks passed!',
@@ -22,7 +22,7 @@ JSON_RESPONSES = {
     'example_broken_ags.ags': {
         "filename": "example_broken_ags.ags",
         "filesize": 4111,
-        "checkers": ["python_ags4 v0.5.0"],
+        "checkers": ["python_ags4 v1.1.0"],
         'dictionary': 'Standard_dictionary_v4_1_1.ags',
         'time': dt.datetime(2021, 8, 23, 14, 25, 43, tzinfo=dt.timezone.utc),
         "message": "13 error(s) found in file!",
@@ -109,7 +109,7 @@ JSON_RESPONSES = {
     'nonsense.AGS': {
         'filename': 'nonsense.AGS',
         'filesize': 9,
-        'checkers': ['python_ags4 v0.5.0'],
+        'checkers': ['python_ags4 v1.1.0'],
         'dictionary': 'Standard_dictionary_v4_1_1.ags',
         'time': dt.datetime(2021, 8, 23, 14, 25, 43, tzinfo=dt.timezone.utc),
         'message': '7 error(s) found in file!',
@@ -138,7 +138,7 @@ JSON_RESPONSES = {
     'random_binary.ags': {
         'filename': 'random_binary.ags',
         'filesize': 1024,
-        'checkers': ['python_ags4 v0.5.0'],
+        'checkers': ['python_ags4 v1.1.0'],
         'dictionary': 'Standard_dictionary_v4_1_1.ags',
         'time': dt.datetime(2021, 8, 23, 14, 25, 43, tzinfo=dt.timezone.utc),
         'message': '37 error(s) found in file!',
@@ -305,7 +305,7 @@ JSON_RESPONSES = {
     'real/AGS3/CG014058_F.ags': {
         'filename': 'CG014058_F.ags',
         'filesize': 50574,
-        'checkers': ['python_ags4 v0.5.0'],
+        'checkers': ['python_ags4 v1.1.0'],
         'dictionary': 'Standard_dictionary_v4_1_1.ags',
         'time': dt.datetime(2021, 8, 23, 14, 25, 43, tzinfo=dt.timezone.utc),
         'message': '1 error(s) found in file!',
@@ -323,7 +323,7 @@ JSON_RESPONSES = {
     'real/Blackburn Southern Bypass.ags': {
         'filename': 'Blackburn Southern Bypass.ags',
         'filesize': 6566,
-        'checkers': ['python_ags4 v0.5.0'],
+        'checkers': ['python_ags4 v1.1.0'],
         'dictionary': 'Standard_dictionary_v4_1_1.ags',
         'time': dt.datetime(2021, 8, 23, 14, 25, 43, tzinfo=dt.timezone.utc),
         'message': '95 error(s) found in file!',
@@ -723,7 +723,7 @@ JSON_RESPONSES = {
     'real/AGS3/A3040_03.ags': {
         'filename': 'A3040_03.ags',
         'filesize': 264526,
-        'checkers': ['python_ags4 v0.5.0'],
+        'checkers': ['python_ags4 v1.1.0'],
         'dictionary': 'Standard_dictionary_v4_1_1.ags',
         'time': dt.datetime(2021, 8, 23, 14, 25, 43, tzinfo=dt.timezone.utc),
         'message': '1 error(s) found in file!',
@@ -759,7 +759,7 @@ GEOJSON_RESPONSES = {
     'example_ags.ags': {
         'filename': 'example_ags.ags',
         'filesize': 4105,
-        'checkers': ['python_ags4 v0.5.0'],
+        'checkers': ['python_ags4 v1.1.0'],
         'dictionary': 'Standard_dictionary_v4_1_1.ags',
         'time': dt.datetime(2021, 8, 23, 14, 25, 43, tzinfo=dt.timezone.utc),
         'message': 'All checks passed!',
@@ -827,7 +827,7 @@ GEOJSON_RESPONSES = {
     'example_broken_ags.ags': {
         "filename": "example_broken_ags.ags",
         "filesize": 4111,
-        "checkers": ["python_ags4 v0.5.0"],
+        "checkers": ["python_ags4 v1.1.0"],
         'dictionary': 'Standard_dictionary_v4_1_1.ags',
         'time': dt.datetime(2021, 8, 23, 14, 25, 43, tzinfo=dt.timezone.utc),
         "message": "13 error(s) found in file!",
@@ -918,7 +918,7 @@ BROKEN_JSON_RESPONSES = [
     {
         'filename': 'nonsense.AGS',
         'filesize': 9,
-        'checkers': ['python_ags4 v0.5.0'],
+        'checkers': ['python_ags4 v1.1.0'],
         'dictionary': 'Standard_dictionary_v4_1_1.ags',
         'time': dt.datetime(2021, 8, 23, 14, 25, 43, tzinfo=dt.timezone.utc),
         'message': '7 error(s) found in file!',
@@ -935,7 +935,7 @@ BROKEN_JSON_RESPONSES = [
     {
         'filename': 'nonsense.AGS',
         'filesize': 9,
-        'checkers': ['python_ags4 v0.5.0'],
+        'checkers': ['python_ags4 v1.1.0'],
         'dictionary': 'Standard_dictionary_v4_1_1.ags',
         'time': dt.datetime(2021, 8, 23, 14, 25, 43, tzinfo=dt.timezone.utc),
         'message': '7 error(s) found in file!',

--- a/test/fixtures_plain_text.py
+++ b/test/fixtures_plain_text.py
@@ -7,7 +7,7 @@ example_ags.ags: All checks passed!
 # Metadata
 
 File size: 4105 bytes
-Checkers: ['python_ags4 v0.5.0']
+Checkers: ['python_ags4 v1.1.0']
 Dictionary: Standard_dictionary_v4_1_1.ags
 Time: 2021-08-23 14:25:43+00:00
 
@@ -25,7 +25,7 @@ example_broken_ags.ags: 13 error(s) found in file!
 # Metadata
 
 File size: 4111 bytes
-Checkers: ['python_ags4 v0.5.0']
+Checkers: ['python_ags4 v1.1.0']
 Dictionary: Standard_dictionary_v4_1_1.ags
 Time: 2021-08-23 14:25:43+00:00
 
@@ -66,7 +66,7 @@ nonsense.AGS: 7 error(s) found in file!
 # Metadata
 
 File size: 9 bytes
-Checkers: ['python_ags4 v0.5.0']
+Checkers: ['python_ags4 v1.1.0']
 Dictionary: Standard_dictionary_v4_1_1.ags
 Time: 2021-08-23 14:25:43+00:00
 
@@ -114,7 +114,7 @@ random_binary.ags: 37 error(s) found in file!
 # Metadata
 
 File size: 1024 bytes
-Checkers: ['python_ags4 v0.5.0']
+Checkers: ['python_ags4 v1.1.0']
 Dictionary: Standard_dictionary_v4_1_1.ags
 Time: 2021-08-23 14:25:43+00:00
 
@@ -198,7 +198,7 @@ Blackburn Southern Bypass.ags: 95 error(s) found in file!
 # Metadata
 
 File size: 6566 bytes
-Checkers: ['python_ags4 v0.5.0']
+Checkers: ['python_ags4 v1.1.0']
 Dictionary: Standard_dictionary_v4_1_1.ags
 Time: 2021-08-23 14:25:43+00:00
 

--- a/test/fixtures_plain_text.py
+++ b/test/fixtures_plain_text.py
@@ -20,7 +20,7 @@ None
 """,
     'example_broken_ags.ags': """
 ================================================================================
-example_broken_ags.ags: 13 error(s) found in file!
+example_broken_ags.ags: 14 error(s) found in file!
 
 # Metadata
 
@@ -53,7 +53,11 @@ Line: 32 - Does not start with a valid data descriptor.
 Line: 35 - Does not start with a valid data descriptor.
 Line: 37 - Does not start with a valid data descriptor.
 
-## AGS Format Rule ?
+## General
+
+Group:  - Could not complete validation. Please fix listed errors and try again.
+
+## Validator Process Error
 
 Group:  - Line 31 does not have the same number of entries as the HEADING row in TYPE.
 

--- a/test/unit/test_checkers.py
+++ b/test/unit/test_checkers.py
@@ -25,12 +25,12 @@ AGS_FILE_DATA = {
     ('nonsense.AGS', {'AGS Format Rule 2a', 'AGS Format Rule 3', 'AGS Format Rule 5', 'AGS Format Rule 13',
                       'AGS Format Rule 14', 'AGS Format Rule 15', 'AGS Format Rule 17'}),
     ('empty.ags', {'AGS Format Rule 13', 'AGS Format Rule 14', 'AGS Format Rule 15', 'AGS Format Rule 17'}),
-    ('real/AGS3/A3040_03.ags', {'AGS Format Rule 3'}),
+    ('real/AGS3/A3040_03.ags', {'AGS Format Rule 3', 'Validator Process Error'}),
     ('real/43370.ags', {'General', 'AGS Format Rule 2a', 'AGS Format Rule 1'}),
-    ('real/JohnStPrimarySchool.ags', {'AGS Format Rule 3', 'AGS Format Rule 5', 'AGS Format Rule ?',
-                                      'AGS Format Rule 4', 'AGS Format Rule 2a'}),
-    ('real/AGS3/19684.ags', {'AGS Format Rule 3'}),
-    ('real/AGS3/E52A4379 (2).ags', {'AGS Format Rule 3'}),
+    ('real/JohnStPrimarySchool.ags', {'General', 'AGS Format Rule 3', 'AGS Format Rule 5',
+                                      'AGS Format Rule 4', 'AGS Format Rule 2a', 'Validator Process Error'}),
+    ('real/AGS3/19684.ags', {'AGS Format Rule 3', 'Validator Process Error'}),
+    ('real/AGS3/E52A4379 (2).ags', {'AGS Format Rule 3', 'Validator Process Error'}),
 ])
 def test_check_ags(filename, expected_rules):
     """Check that broken rules are returned and exceptions handled correctly."""


### PR DESCRIPTION
This PR updates the `python-ags` dependency to `v1.1.0`. The rule keys and test fixtures have been updated.

The tests pass, (other than those dependent on the OGCAPI server due to issues with that upstream server).

Closes #152