### PR TITLE
Clear map key between validation runs

### DIFF
--- a/app/static/js/validation-map.js
+++ b/app/static/js/validation-map.js
@@ -109,6 +109,7 @@ vMap.resetValidationMap=function(){
     // force map redraw when showing map and clear out any existing layers
     vMap.map.lyrs.GeoJSON.clearLayers();
     vMap.map.lMap.invalidateSize();
+    $("#res_MapFrame .mapKey").remove();
     $("#res_MapFrame").show();
     return true;
     };


### PR DESCRIPTION
Removes instances of mapKey when resetting the validation map, so only files from the current validation run are displayed.
Closes #163 