### PR TITLE
Use borehole limit constant

### DIFF
--- a/app/routes/ags_export_by_polygon.py
+++ b/app/routes/ags_export_by_polygon.py
@@ -67,7 +67,7 @@ def ags_export_by_polygon(
     except shapely.errors.GEOSException:
         raise HTTPException(status_code=422, detail="Invalid polygon")
 
-    url = BOREHOLE_INDEX_URL.format(polygon=polygon)
+    url = BOREHOLE_INDEX_URL.format(polygon=polygon, borehole_export_limit=BOREHOLE_EXPORT_LIMIT)
 
     try:
         response = requests.get(url, timeout=10)

--- a/app/routes/utils.py
+++ b/app/routes/utils.py
@@ -15,7 +15,7 @@ BOREHOLE_VIEWER_URL = "https://gwbv.bgs.ac.uk/GWBV/viewborehole?loca_id={bgs_loc
 BOREHOLE_EXPORT_URL = "https://gwbv.bgs.ac.uk/ags_export?loca_ids={bgs_loca_id}"
 BOREHOLE_INDEX_URL = (
     "https://ogcapi.bgs.ac.uk/collections/agsboreholeindex/items?f=json"
-    "&properties=bgs_loca_id&filter=INTERSECTS(shape,{polygon})&limit=50"
+    "&properties=bgs_loca_id&filter=INTERSECTS(shape,{polygon})&limit={borehole_export_limit}"
 )
 
 log_responses = dict(error_responses)

--- a/test/integration/test_ags_export_by_polygon.py
+++ b/test/integration/test_ags_export_by_polygon.py
@@ -1,5 +1,6 @@
 """Tests for API responses."""
 from io import BytesIO
+import re
 import zipfile
 
 import pytest
@@ -46,6 +47,37 @@ def test_get_ags_exporter_by_polygon(client, count_only):
                 assert bgs_loca_id in metadata_text
             for bgs_proj_id in bgs_proj_ids:
                 assert f'Project : {bgs_proj_id}' in metadata_text
+
+
+@pytest.mark.xfail(IN_GITHUB_ACTIONS, reason="Upstream URL not available from Github Actions")
+def test_get_ags_exporter_by_polygon_with_more_than_10_polygons(client):
+    # Arrange
+    # There should be 28 boreholes in this area, this should pass for a limit of 50,
+    # and it should fail for a limit of 10
+    polygon = 'POLYGON((-3.946 56.065,-3.640 56.065,-3.640 55.966,-3.946 55.966,-3.946 56.065))'
+    query = f'{API_VERSION}/ags_export_by_polygon/?polygon={polygon}'
+    ags_metadata_file_name = 'FILE/BGSFileSet01/BGS_download_metadata.txt'
+
+    # Act
+    with client as ac:
+        response = ac.get(query)
+
+    # Assert
+    assert response.status_code == 200
+    assert response.headers["Content-Disposition"] == 'attachment; filename="boreholes.zip"'
+    assert response.headers["Content-Type"] == "application/x-zip-compressed"
+    assert len(response.content) > 0
+
+    assert zipfile.is_zipfile(BytesIO(response.content))
+    with zipfile.ZipFile(BytesIO(response.content)) as ags_zip:
+        # Check that metadata.txt lists 28 loca IDs
+        with ags_zip.open(ags_metadata_file_name) as metadata_file:
+            # find the pattern 20200205093727287902;20200205093727287903;2020...
+            regex = r'\d+(;\d+)+'
+            metadata_text = metadata_file.read().decode()
+            match = re.search(regex, metadata_text)
+            assert match
+            assert len(match.group(0).split(';')) == 28
 
 
 @pytest.mark.parametrize('polygon, count', [


### PR DESCRIPTION
I'm not sure how 7e788d281330cc9c0a8c9d7645084f32544b6de6 was missed given where it is in the code! However, the tests were insufficient to pick this up, we were only testing for a large number that exceeds 50. I have added a test for 28 boreholes, above the old limit of 10 but within the new limit of 50. This fails if I hard-code the limit back to 10 in the upstream URL.

If the limit is raised again this test should be amended before changing the route code.

The final commit replaces the hard-coded limit with the constant.